### PR TITLE
Live drag-strip race view, honest pace chart & winner podium — UI/UX/viz overhaul

### DIFF
--- a/components/main/DragStrip.tsx
+++ b/components/main/DragStrip.tsx
@@ -1,0 +1,245 @@
+// components/main/DragStrip.tsx
+//
+// The arcade spectacle: a literal drag strip. Each model is a dragster on its own asphalt
+// lane. It idles at the start line until its first token arrives (TTFT = launch), then
+// drives right; horizontal position = its share of the leader's output (real overtakes &
+// fall-backs), speed-streak intensity = live throughput, and it lunges across the checkered
+// the instant its stream finishes. One rAF loop reads the shared LaneBuffers and mutates
+// styles imperatively — no React re-render per token. Honest by construction: every channel
+// maps to a real measured quantity, never a fabricated "distance".
+//
+// Position uses CSS `left: calc(frac * (100% - carWidth))` so the browser resolves it
+// against the real track width every frame — no brittle JS measurement.
+
+import React, { useEffect, useRef } from 'react';
+import { LaneBuffer, recentCharsPerSec } from '../../utils/raceBuffers';
+import { PaceLane } from './LivePaceChart';
+
+interface DragStripProps {
+  lanes: PaceLane[];
+  buffersRef: React.MutableRefObject<Record<string, LaneBuffer>>;
+  goTimeRef: React.MutableRefObject<number>;
+  running: boolean;
+  reducedMotion?: boolean;
+}
+
+const FRONT_ANCHOR = 0.82; // leader cruises near the finish; the last stretch is the line
+const CAR_W = 60; // px, keeps the nose inside the strip until the finish lunge
+
+function compact(n: number): string {
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+  return String(Math.round(n));
+}
+
+// Side-view top-fuel dragster, facing right. Big slicks at the rear (left).
+const Dragster: React.FC<{ color: string }> = ({ color }) => (
+  <svg viewBox="0 0 72 30" width={CAR_W} height={25} className="overflow-visible">
+    {/* engine flame trailing the rear */}
+    <g className="car-flame">
+      <path d="M6 15 L-6 12 L-2 15 L-7 18 L6 18 Z" fill="#fbbf24" />
+      <path d="M5 15.5 L-2 13.5 L0 15.5 L-3 17 L5 17 Z" fill="#fb7185" />
+    </g>
+    {/* rear wing */}
+    <rect x="3" y="5" width="11" height="3" rx="1" fill={color} />
+    <rect x="7" y="8" width="2" height="6" fill="#0a0b0d" />
+    {/* long chassis to needle nose */}
+    <path d="M9 17 L44 15.5 L70 19.5 L70 21 L16 22.5 Q9 22 9 17 Z" fill={color} />
+    <path d="M44 15.5 L70 19.5 L70 21 L52 19 Z" fill="#0a0b0d" opacity="0.35" />
+    {/* engine block */}
+    <rect x="20" y="11.5" width="9" height="5" rx="1" fill="#0a0b0d" opacity="0.8" />
+    {/* driver bubble */}
+    <path d="M31 15.5 q4 -5 9 -0.5 z" fill="#0a0b0d" opacity="0.85" />
+    <circle cx="35.5" cy="13.6" r="1.9" fill={color} />
+    {/* rear slick (left) */}
+    <circle cx="16" cy="21.5" r="7.5" fill="#08090b" stroke={color} strokeWidth="1.6" />
+    <circle cx="16" cy="21.5" r="2.6" fill={color} />
+    {/* front wheel (right) */}
+    <circle cx="60" cy="23.5" r="4.4" fill="#08090b" stroke={color} strokeWidth="1.2" />
+    <circle cx="60" cy="23.5" r="1.5" fill={color} />
+  </svg>
+);
+
+const DragStrip: React.FC<DragStripProps> = ({ lanes, buffersRef, running, reducedMotion = false }) => {
+  const carRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const streakRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const readoutRefs = useRef<Record<string, HTMLSpanElement | null>>({});
+  const subRefs = useRef<Record<string, HTMLSpanElement | null>>({});
+  const laneRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const curFracRef = useRef<Record<string, number>>({});
+  const rafRef = useRef<number | null>(null);
+  const lastDrawRef = useRef<number>(0);
+
+  const lanesRef = useRef(lanes);
+  lanesRef.current = lanes;
+
+  useEffect(() => {
+    const draw = () => {
+      const buffers = buffersRef.current || {};
+      const ls = lanesRef.current;
+
+      let leaderChars = 1;
+      let leaderId: string | null = null;
+      for (const lane of ls) {
+        const b = buffers[lane.id];
+        if (b && !b.errored && b.chars > leaderChars) {
+          leaderChars = b.chars;
+          leaderId = lane.id;
+        }
+      }
+
+      for (const lane of ls) {
+        const b = buffers[lane.id];
+        const car = carRefs.current[lane.id];
+        if (!b || !car) continue;
+
+        const launched = b.firstTokenT != null;
+
+        let frac: number;
+        if (b.errored) frac = curFracRef.current[lane.id] ?? 0;
+        else if (b.done) frac = 1;
+        else frac = Math.min(1, b.chars / leaderChars) * FRONT_ANCHOR;
+
+        const cur = curFracRef.current[lane.id] ?? 0;
+        const next = reducedMotion || b.done || b.errored ? frac : cur + (frac - cur) * 0.16;
+        curFracRef.current[lane.id] = next;
+
+        // Browser resolves the percentage against the real track width — no JS measurement.
+        car.style.left = `calc(${next.toFixed(4)} * (100% - ${CAR_W}px))`;
+        car.dataset.running = launched && !b.done && !b.errored ? 'true' : 'false';
+        car.dataset.leader = lane.id === leaderId && !b.done && !b.errored ? 'true' : 'false';
+        car.style.opacity = b.errored ? '0.35' : '1';
+
+        const speed = recentCharsPerSec(b);
+        const streak = streakRefs.current[lane.id];
+        if (streak) {
+          const active = launched && !b.done && !b.errored && speed > 15;
+          streak.style.opacity = active ? String(Math.min(1, 0.25 + speed / 600)) : '0';
+          streak.style.width = active ? `${Math.min(64, 14 + speed / 9).toFixed(0)}px` : '0px';
+        }
+
+        const lane2 = laneRefs.current[lane.id];
+        if (lane2) lane2.dataset.state = b.errored ? 'out' : b.done ? 'fin' : launched ? 'go' : 'stage';
+
+        const readout = readoutRefs.current[lane.id];
+        const sub = subRefs.current[lane.id];
+        if (readout) {
+          if (b.errored) readout.textContent = 'OUT';
+          else if (b.done) readout.textContent = `${(b.lastT / 1000).toFixed(2)}s`;
+          else if (launched) readout.textContent = compact(speed);
+          else readout.textContent = '—';
+        }
+        if (sub) {
+          if (b.errored) sub.textContent = 'DNF';
+          else if (b.done) sub.textContent = 'ET · finished';
+          else if (launched) sub.textContent = `c/s · ${compact(b.chars)} ch`;
+          else sub.textContent = 'staging';
+        }
+      }
+    };
+
+    let stopped = false;
+    const loop = () => {
+      if (stopped) return;
+      const now = performance.now();
+      const minGap = reducedMotion ? 100 : 0;
+      if (now - lastDrawRef.current >= minGap) {
+        lastDrawRef.current = now;
+        draw();
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    if (running) rafRef.current = requestAnimationFrame(loop);
+    else draw();
+
+    return () => {
+      stopped = true;
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [running, reducedMotion, buffersRef]);
+
+  return (
+    <div className="space-y-2">
+      {lanes.map((lane, i) => (
+        <div
+          key={lane.id}
+          ref={(el) => {
+            laneRefs.current[lane.id] = el;
+          }}
+          data-state="stage"
+          className="group grid grid-cols-[104px_minmax(0,1fr)_72px] items-stretch gap-2 sm:grid-cols-[128px_minmax(0,1fr)_84px]"
+        >
+          {/* lane head: number + provider */}
+          <div className="flex min-w-0 items-center gap-2 rounded-l-lg border border-r-0 border-white/5 bg-black/40 px-2">
+            <span className="font-speed shrink-0 text-lg text-[var(--text-subtle)]">{i + 1}</span>
+            <span className="h-6 w-1 shrink-0 rounded-full" style={{ background: lane.color, boxShadow: `0 0 8px ${lane.color}` }} />
+            <span className="flex min-w-0 flex-col leading-tight">
+              <span className="truncate text-[13px] font-semibold text-white" title={lane.label}>
+                {lane.label}
+              </span>
+              <span className="truncate text-[10px] text-[var(--text-muted)]" title={lane.sublabel}>
+                {lane.sublabel}
+              </span>
+            </span>
+          </div>
+
+          {/* the strip */}
+          <div className="asphalt relative h-14 overflow-hidden border-y border-white/5">
+            {/* lane centerline */}
+            <div className="lane-dashes pointer-events-none absolute inset-x-0 top-1/2 h-[2px] -translate-y-1/2 opacity-60" />
+            {/* start line */}
+            <div className="pointer-events-none absolute inset-y-0 left-0 w-[3px] bg-white/40" />
+            {/* finish checker */}
+            <div className="checker-bg pointer-events-none absolute inset-y-0 right-0 w-3" />
+            {/* the dragster */}
+            <div
+              ref={(el) => {
+                carRefs.current[lane.id] = el;
+              }}
+              data-running="false"
+              data-leader="false"
+              className="dragster absolute top-1/2"
+              style={{ left: 0, transform: 'translateY(-50%)', willChange: 'left' }}
+            >
+              {/* speed streak trailing behind */}
+              <div
+                ref={(el) => {
+                  streakRefs.current[lane.id] = el;
+                }}
+                className="speed-streak absolute right-full top-1/2 h-[3px] -translate-y-1/2 rounded-full"
+                style={{ color: lane.color, opacity: 0, width: 0 }}
+              />
+              <Dragster color={lane.color} />
+              {/* leader crown */}
+              <span className="leader-crown absolute -top-1 right-1 text-[11px]" aria-hidden>
+                👑
+              </span>
+            </div>
+          </div>
+
+          {/* readout */}
+          <div className="flex flex-col items-end justify-center rounded-r-lg border border-l-0 border-white/5 bg-black/40 px-2 text-right">
+            <span
+              ref={(el) => {
+                readoutRefs.current[lane.id] = el;
+              }}
+              className="font-speed text-[15px] text-white"
+            >
+              —
+            </span>
+            <span
+              ref={(el) => {
+                subRefs.current[lane.id] = el;
+              }}
+              className="truncate text-[9px] text-[var(--text-muted)]"
+            >
+              staging
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default React.memo(DragStrip);

--- a/components/main/LivePaceChart.tsx
+++ b/components/main/LivePaceChart.tsx
@@ -1,0 +1,341 @@
+// components/main/LivePaceChart.tsx
+//
+// THE headline visualization. A hand-rolled SVG pace chart driven by one
+// requestAnimationFrame loop that reads mutable LaneBuffers from a ref — it never
+// triggers a React re-render while the race runs.
+//
+// Encoding (both axes are real measured quantities — never two conflicting "ahead"s):
+//   X = elapsed seconds since the shared "Go!"  (so a slow-to-respond model's line
+//       literally starts further right — TTFT becomes geometry, no label needed)
+//   Y = cumulative characters streamed          (slope = throughput, height = volume)
+//
+// On finish the loop stops and the last frame is left frozen (a faithful record of the
+// client-observed stream), ready to be screenshotted / exported.
+
+import React, { useEffect, useRef } from 'react';
+import { LaneBuffer, decimate, recentCharsPerSec } from '../../utils/raceBuffers';
+
+export interface PaceLane {
+  id: string;
+  label: string; // provider display name
+  sublabel: string; // model name
+  color: string; // provider solid color
+}
+
+interface LivePaceChartProps {
+  lanes: PaceLane[];
+  buffersRef: React.MutableRefObject<Record<string, LaneBuffer>>;
+  goTimeRef: React.MutableRefObject<number>;
+  running: boolean;
+  reducedMotion?: boolean;
+  normalize?: boolean;
+}
+
+const VB_W = 1000;
+const VB_H = 440;
+const PAD = { l: 22, r: 116, t: 16, b: 30 };
+const PLOT_W = VB_W - PAD.l - PAD.r;
+const PLOT_H = VB_H - PAD.t - PAD.b;
+
+function compact(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+  return String(Math.round(n));
+}
+
+const LivePaceChart: React.FC<LivePaceChartProps> = ({
+  lanes,
+  buffersRef,
+  goTimeRef,
+  running,
+  reducedMotion = false,
+  normalize = false,
+}) => {
+  const pathEls = useRef<Record<string, SVGPathElement | null>>({});
+  const headEls = useRef<Record<string, SVGCircleElement | null>>({});
+  const flagEls = useRef<Record<string, SVGTextElement | null>>({});
+  const cursorEl = useRef<SVGLineElement | null>(null);
+  const xLabelEl = useRef<SVGTSpanElement | null>(null);
+  const yLabelEl = useRef<SVGTSpanElement | null>(null);
+  const emptyEl = useRef<SVGTextElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const lastDrawRef = useRef<number>(0);
+
+  // Keep a stable reference to lanes for the rAF loop without re-subscribing each render.
+  const lanesRef = useRef(lanes);
+  lanesRef.current = lanes;
+  const normalizeRef = useRef(normalize);
+  normalizeRef.current = normalize;
+
+  useEffect(() => {
+    const draw = (nowReal: number) => {
+      const buffers = buffersRef.current;
+      const ls = lanesRef.current;
+
+      // Determine the time axis extent.
+      let maxLastT = 0;
+      let anyData = false;
+      let globalMaxChars = 1;
+      let leaderChars = 1;
+      for (const lane of ls) {
+        const b = buffers[lane.id];
+        if (!b) continue;
+        if (b.samples.length) anyData = true;
+        if (b.lastT > maxLastT) maxLastT = b.lastT;
+        if (!b.errored && b.chars > globalMaxChars) globalMaxChars = b.chars;
+        if (!b.errored && b.chars > leaderChars) leaderChars = b.chars;
+      }
+      const showFlags = ls.length <= 8; // beyond this, lean on the standings list for identity
+      const liveT = running ? performance.now() - goTimeRef.current : maxLastT;
+      const xMax = Math.max(liveT, maxLastT, 1000) * 1.04;
+      const useNorm = normalizeRef.current;
+      const yDenom = useNorm ? Math.max(leaderChars * 1.08, 1) : Math.max(globalMaxChars * 1.08, 1);
+
+      const x = (t: number) => PAD.l + (t / xMax) * PLOT_W;
+      const y = (chars: number) => PAD.t + PLOT_H - (Math.min(chars, yDenom) / yDenom) * PLOT_H;
+
+      if (emptyEl.current) emptyEl.current.style.opacity = anyData ? '0' : '1';
+
+      // Leader (most characters, not errored) gets emphasis.
+      let leaderId: string | null = null;
+      let leaderMax = -1;
+      for (const lane of ls) {
+        const b = buffers[lane.id];
+        if (b && !b.errored && b.chars > leaderMax) {
+          leaderMax = b.chars;
+          leaderId = lane.id;
+        }
+      }
+
+      for (const lane of ls) {
+        const b = buffers[lane.id];
+        const path = pathEls.current[lane.id];
+        const head = headEls.current[lane.id];
+        const flag = flagEls.current[lane.id];
+        if (!b || !path) continue;
+
+        if (b.samples.length === 0) {
+          path.setAttribute('d', '');
+          if (head) head.setAttribute('opacity', '0');
+          if (flag) flag.setAttribute('opacity', '0');
+          continue;
+        }
+
+        const pts = decimate(b.samples);
+        let d = '';
+        for (let i = 0; i < pts.length; i++) {
+          const px = x(pts[i].t).toFixed(1);
+          const py = y(pts[i].chars).toFixed(1);
+          d += (i === 0 ? 'M' : 'L') + px + ',' + py + ' ';
+        }
+        path.setAttribute('d', d.trim());
+
+        const isLeader = lane.id === leaderId;
+        path.setAttribute('stroke-width', isLeader ? '3' : '2');
+        path.setAttribute('opacity', b.errored ? '0.28' : '1');
+        path.style.filter = isLeader && !b.errored ? `drop-shadow(0 0 6px ${lane.color}aa)` : 'none';
+
+        const last = pts[pts.length - 1];
+        const hx = x(last.t);
+        const hy = y(last.chars);
+        if (head) {
+          head.setAttribute('cx', hx.toFixed(1));
+          head.setAttribute('cy', hy.toFixed(1));
+          head.setAttribute('r', b.done ? '4.5' : isLeader ? '4' : '3');
+          head.setAttribute('opacity', b.errored ? '0.3' : '1');
+        }
+        if (flag) {
+          if (!showFlags) {
+            flag.setAttribute('opacity', '0');
+          } else {
+            const fy = Math.max(PAD.t + 8, Math.min(hy, PAD.t + PLOT_H - 4));
+            const nearEdge = hx > PAD.l + PLOT_W - 70;
+            flag.setAttribute('text-anchor', nearEdge ? 'end' : 'start');
+            flag.setAttribute('x', (nearEdge ? hx - 7 : hx + 8).toFixed(1));
+            flag.setAttribute('y', (fy + 3.5).toFixed(1));
+            flag.setAttribute('opacity', b.errored ? '0.4' : '1');
+            if (b.errored) {
+              flag.textContent = 'error';
+            } else if (b.done) {
+              flag.textContent =
+                b.finalOutputTokens != null ? `${compact(b.finalOutputTokens)} tok` : `${compact(b.chars)} ch`;
+            } else {
+              const cps = recentCharsPerSec(b);
+              flag.textContent = `${compact(b.chars)} · ${compact(cps)}/s`;
+            }
+          }
+        }
+      }
+
+      // Sweeping NOW cursor + axis labels.
+      if (cursorEl.current) {
+        if (running && !reducedMotion && anyData) {
+          const cx = x(liveT);
+          cursorEl.current.setAttribute('x1', cx.toFixed(1));
+          cursorEl.current.setAttribute('x2', cx.toFixed(1));
+          cursorEl.current.setAttribute('opacity', '0.5');
+        } else {
+          cursorEl.current.setAttribute('opacity', '0');
+        }
+      }
+      if (xLabelEl.current) xLabelEl.current.textContent = `${(xMax / 1000).toFixed(1)}s`;
+      if (yLabelEl.current) {
+        yLabelEl.current.textContent = useNorm ? '% of most output' : `${compact(yDenom)} chars`;
+      }
+    };
+
+    let stopped = false;
+    const loop = () => {
+      if (stopped) return;
+      const now = performance.now();
+      // Under reduced motion, cap redraws to ~8fps (no smooth sweep).
+      const minGap = reducedMotion ? 120 : 0;
+      if (now - lastDrawRef.current >= minGap) {
+        lastDrawRef.current = now;
+        draw(now);
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    if (running) {
+      rafRef.current = requestAnimationFrame(loop);
+    } else {
+      // Final freeze frame.
+      draw(performance.now());
+    }
+
+    return () => {
+      stopped = true;
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [running, reducedMotion, normalize, buffersRef, goTimeRef]);
+
+  // Static horizontal gridlines (4 bands).
+  const gridYs = [0.25, 0.5, 0.75].map((f) => PAD.t + PLOT_H - f * PLOT_H);
+
+  return (
+    <svg
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      width="100%"
+      className="block"
+      style={{ minHeight: 220, maxHeight: 460 }}
+      role="img"
+      aria-label="Live pace chart: cumulative characters streamed over elapsed time for each model. The accessible standings list below carries the same information as text."
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {/* plot frame */}
+      <line
+        x1={PAD.l}
+        y1={PAD.t + PLOT_H}
+        x2={PAD.l + PLOT_W}
+        y2={PAD.t + PLOT_H}
+        stroke="rgba(255,255,255,0.14)"
+        strokeWidth={1}
+      />
+      <line
+        x1={PAD.l}
+        y1={PAD.t}
+        x2={PAD.l}
+        y2={PAD.t + PLOT_H}
+        stroke="rgba(255,255,255,0.08)"
+        strokeWidth={1}
+      />
+      {gridYs.map((gy, i) => (
+        <line
+          key={i}
+          x1={PAD.l}
+          y1={gy}
+          x2={PAD.l + PLOT_W}
+          y2={gy}
+          stroke="rgba(255,255,255,0.05)"
+          strokeWidth={1}
+        />
+      ))}
+
+      {/* axis labels */}
+      <text x={PAD.l} y={PAD.t - 4} fill="rgba(244,245,247,0.45)" fontSize={11} fontFamily="inherit">
+        <tspan ref={yLabelEl}>chars</tspan>
+      </text>
+      <text
+        x={PAD.l + PLOT_W}
+        y={PAD.t + PLOT_H + 20}
+        fill="rgba(244,245,247,0.45)"
+        fontSize={11}
+        textAnchor="end"
+        fontFamily="inherit"
+      >
+        <tspan ref={xLabelEl}>0s</tspan>
+      </text>
+      <text
+        x={PAD.l}
+        y={PAD.t + PLOT_H + 20}
+        fill="rgba(244,245,247,0.45)"
+        fontSize={11}
+        fontFamily="inherit"
+      >
+        0s · launch
+      </text>
+
+      {/* sweeping NOW cursor */}
+      <line
+        ref={cursorEl}
+        x1={PAD.l}
+        y1={PAD.t}
+        x2={PAD.l}
+        y2={PAD.t + PLOT_H}
+        stroke="rgba(255,255,255,0.55)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+        opacity={0}
+      />
+
+      {/* one polyline + head + value flag per lane */}
+      {lanes.map((lane) => (
+        <g key={lane.id}>
+          <path
+            ref={(el) => {
+              pathEls.current[lane.id] = el;
+            }}
+            fill="none"
+            stroke={lane.color}
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            d=""
+          />
+          <circle
+            ref={(el) => {
+              headEls.current[lane.id] = el;
+            }}
+            r={3}
+            fill={lane.color}
+            opacity={0}
+          />
+          <text
+            ref={(el) => {
+              flagEls.current[lane.id] = el;
+            }}
+            fontSize={11.5}
+            fontFamily="inherit"
+            fill={lane.color}
+            opacity={0}
+          />
+        </g>
+      ))}
+
+      <text
+        ref={emptyEl}
+        x={PAD.l + PLOT_W / 2}
+        y={PAD.t + PLOT_H / 2}
+        fill="rgba(244,245,247,0.4)"
+        fontSize={13}
+        textAnchor="middle"
+        fontFamily="inherit"
+      >
+        Waiting for the first token…
+      </text>
+    </svg>
+  );
+};
+
+export default React.memo(LivePaceChart);

--- a/components/main/RaceLane.tsx
+++ b/components/main/RaceLane.tsx
@@ -16,6 +16,8 @@ export interface RaceLaneProps {
   laneColor?: string; // optional tint for lane & charts cohesion
   // Optional broadcast control to force collapse/expand from parent toolbars
   force?: { version: number; collapsed: boolean };
+  // Initial expanded state — lanes start collapsed when the pace chart leads the layout
+  initialExpanded?: boolean;
 }
 
 function formatMs(ms?: number) {
@@ -25,7 +27,7 @@ function formatMs(ms?: number) {
 function calcTps(metrics: CompletionMetrics | null): string {
   if (!metrics || !metrics.finishTime || !metrics.firstTokenTime) return 'N/A';
   const duration = (metrics.finishTime - metrics.firstTokenTime) / 1000;
-  if (duration <= 0) return 'N/A';
+  if (duration < 0.15) return 'N/A'; // sub-150ms window = buffered flush, not real throughput
   const out = typeof metrics.outputTokens === 'number' ? metrics.outputTokens : metrics.tokenCount;
   return (out / duration).toFixed(2);
 }
@@ -48,10 +50,10 @@ const StatusBadge: React.FC<{ status: LaneStatus }> = ({ status }) => {
       label: 'Racing'
     },
     finish: {
-      bg: 'bg-cyan-500/20',
-      border: 'border-cyan-500/40',
-      text: 'text-cyan-400',
-      dot: 'bg-cyan-400',
+      bg: 'bg-white/10',
+      border: 'border-white/20',
+      text: 'text-zinc-200',
+      dot: 'bg-zinc-200',
       label: 'Finished'
     },
     error: {
@@ -81,6 +83,7 @@ const RaceLane: React.FC<RaceLaneProps> = ({
   error,
   laneColor = '#38bdf8', // cyan default
   force,
+  initialExpanded = true,
 }) => {
   const providerCfg = getProviderById(providerName);
   const displayName = providerCfg?.displayName || providerName;
@@ -96,7 +99,7 @@ const RaceLane: React.FC<RaceLaneProps> = ({
   const total = metrics?.finishTime ? metrics.finishTime - metrics.startTime : undefined;
 
   // Expanded state for the response area
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(initialExpanded);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const autoCollapseTimer = useRef<number | null>(null);
 
@@ -162,7 +165,7 @@ const RaceLane: React.FC<RaceLaneProps> = ({
                 }`}
             />
             <div
-              className={`w-2.5 h-2.5 rounded-full transition-all duration-200 border border-zinc-800 ${status === 'finish' ? 'bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.8)]' : 'bg-black/50'
+              className={`w-2.5 h-2.5 rounded-full transition-all duration-200 border border-zinc-800 ${status === 'finish' ? 'bg-zinc-200 shadow-[0_0_8px_rgba(255,255,255,0.7)]' : 'bg-black/50'
                 }`}
             />
           </div>
@@ -240,7 +243,7 @@ const RaceLane: React.FC<RaceLaneProps> = ({
               {isLoading && !responseText && !error && (
                 <div className="space-y-3 py-2">
                   <div className="flex items-center gap-2 text-[var(--text-muted)] text-sm">
-                    <div className="w-4 h-4 border-2 border-white/20 border-t-cyan-400 rounded-full animate-spin" />
+                    <div className="w-4 h-4 border-2 border-white/20 border-t-[var(--accent)] rounded-full animate-spin" />
                     <span className="animate-pulse">Waiting for first token...</span>
                   </div>
                   {/* Shimmer skeleton lines */}
@@ -317,4 +320,4 @@ const RaceLane: React.FC<RaceLaneProps> = ({
   );
 };
 
-export default RaceLane;
+export default React.memo(RaceLane);

--- a/components/main/ResultsDisplay.tsx
+++ b/components/main/ResultsDisplay.tsx
@@ -19,16 +19,57 @@ interface ResultsDisplayProps {
   results: ResultState[];
   hideFailed?: boolean;
   force?: { version: number; collapsed: boolean };
+  // When the pace chart leads the layout, lanes start collapsed as readable drawers.
+  compact?: boolean;
+  // Optional: run the simulated test race (shown in the empty state for keyless visitors).
+  onDemo?: () => void;
 }
 
-const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, hideFailed = false, force }) => {
+const STEPS = [
+  { n: 1, text: 'Open the Racers panel — the sidebar on the left, or tap Racers on mobile.' },
+  { n: 2, text: 'Paste an API key for any provider (stored only in your browser).' },
+  { n: 3, text: 'Pick one or more models to enter the race.' },
+  { n: 4, text: 'Hit Start Race and watch them stream head-to-head.' },
+];
+
+const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, hideFailed = false, force, compact = false, onDemo }) => {
   if (results.length === 0) {
     return (
-      <GlassCard className="py-16 px-8">
-        <div className="flex flex-col items-center justify-center text-center">
-          <p className="text-[var(--text-muted)]">
-            Run a comparison to see results here.
+      <GlassCard className="px-6 py-12" spotlight={false}>
+        <div className="mx-auto flex max-w-lg flex-col items-center text-center">
+          <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-zinc-950 ring-1 ring-white/10">
+            <svg viewBox="0 0 24 24" className="h-7 w-7 text-[var(--accent-light)]" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M5 3v18h2v-7h12V3H5zm2 2h8v3H7V5zm0 5h10v2H7v-2z" strokeLinejoin="round" />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold tracking-tight text-white heading-tight">Line up your racers</h3>
+          <p className="mt-1.5 text-sm leading-relaxed text-[var(--text-muted)]">
+            Add a provider in the <span className="font-medium text-[var(--text)]">Racers</span> panel, choose your models,
+            and start a live head-to-head speed test.
           </p>
+
+          <ol className="mt-6 w-full space-y-2.5 text-left">
+            {STEPS.map((s) => (
+              <li key={s.n} className="flex items-start gap-3">
+                <span className="font-speed mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--accent-muted)] text-xs text-[var(--accent-light)]">
+                  {s.n}
+                </span>
+                <span className="text-sm text-[var(--text-secondary)]">{s.text}</span>
+              </li>
+            ))}
+          </ol>
+
+          {onDemo && (
+            <div className="mt-7 flex flex-col items-center gap-1.5 border-t border-white/5 pt-5">
+              <button onClick={onDemo} className="btn-secondary text-xs">
+                <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M9 3h6M10 3v6l-5.5 9.2A2 2 0 0 0 6.2 21h11.6a2 2 0 0 0 1.7-2.8L14 9V3" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                Watch a demo race
+              </button>
+              <span className="text-[11px] text-[var(--text-subtle)]">Simulated — no API key, just to see how it looks</span>
+            </div>
+          )}
         </div>
       </GlassCard>
     );
@@ -55,6 +96,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, hideFailed = f
             error={result.error}
             laneColor={getProviderColor(result.providerName).solid}
             force={force}
+            initialExpanded={!compact}
           />
         </div>
       ))}

--- a/components/main/StandingsTicker.tsx
+++ b/components/main/StandingsTicker.tsx
@@ -1,0 +1,165 @@
+// components/main/StandingsTicker.tsx
+//
+// The always-visible, colorblind-safe, screen-reader-friendly "who leads now" list.
+// Reads the same LaneBuffers as the pace chart on a throttled interval and re-orders
+// rows with a FLIP transform animation (skipped under prefers-reduced-motion).
+//
+// Ranking is by cumulative characters streamed — the honest "furthest along right now".
+// Finished lanes keep their final value and gain a finish flag.
+
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { LaneBuffer, recentCharsPerSec } from '../../utils/raceBuffers';
+import { PaceLane } from './LivePaceChart';
+
+interface StandingsTickerProps {
+  lanes: PaceLane[];
+  buffersRef: React.MutableRefObject<Record<string, LaneBuffer>>;
+  running: boolean;
+  reducedMotion?: boolean;
+}
+
+interface Row {
+  id: string;
+  label: string;
+  sublabel: string;
+  color: string;
+  chars: number;
+  cps: number;
+  done: boolean;
+  errored: boolean;
+  finalOutputTokens: number | null;
+}
+
+function compact(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+  return String(Math.round(n));
+}
+
+function buildRows(lanes: PaceLane[], buffers: Record<string, LaneBuffer>): Row[] {
+  const rows: Row[] = lanes.map((lane) => {
+    const b = buffers[lane.id];
+    return {
+      id: lane.id,
+      label: lane.label,
+      sublabel: lane.sublabel,
+      color: lane.color,
+      chars: b?.chars ?? 0,
+      cps: b && !b.done ? recentCharsPerSec(b) : 0,
+      done: b?.done ?? false,
+      errored: b?.errored ?? false,
+      finalOutputTokens: b?.finalOutputTokens ?? null,
+    };
+  });
+  rows.sort((a, b) => {
+    if (a.errored !== b.errored) return a.errored ? 1 : -1; // errors sink
+    return b.chars - a.chars;
+  });
+  return rows;
+}
+
+const StandingsTicker: React.FC<StandingsTickerProps> = ({
+  lanes,
+  buffersRef,
+  running,
+  reducedMotion = false,
+}) => {
+  const [rows, setRows] = useState<Row[]>(() => buildRows(lanes, buffersRef.current));
+  const rowRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+  const prevTops = useRef<Map<string, number>>(new Map());
+
+  // Sample the buffers on an interval (cheap, ~7/sec) while the race runs.
+  useEffect(() => {
+    setRows(buildRows(lanes, buffersRef.current));
+    if (!running) return;
+    const tick = () => setRows(buildRows(lanes, buffersRef.current));
+    const id = window.setInterval(tick, 150);
+    return () => window.clearInterval(id);
+  }, [running, lanes, buffersRef]);
+
+  // FLIP: animate rows sliding to their new ranked positions.
+  useLayoutEffect(() => {
+    if (reducedMotion) return;
+    const newTops = new Map<string, number>();
+    rowRefs.current.forEach((el, id) => newTops.set(id, el.getBoundingClientRect().top));
+    newTops.forEach((top, id) => {
+      const prev = prevTops.current.get(id);
+      const el = rowRefs.current.get(id);
+      if (prev != null && el) {
+        const dy = prev - top;
+        if (Math.abs(dy) > 0.5) {
+          el.style.transition = 'none';
+          el.style.transform = `translateY(${dy}px)`;
+          requestAnimationFrame(() => {
+            el.style.transition = 'transform 320ms cubic-bezier(0.16, 1, 0.3, 1)';
+            el.style.transform = '';
+          });
+        }
+      }
+    });
+    prevTops.current = newTops;
+  }, [rows, reducedMotion]);
+
+  const leaderChars = rows.find((r) => !r.errored)?.chars ?? 0;
+
+  return (
+    <div aria-live="off">
+      <ol className="space-y-1.5" reversed={false}>
+        {rows.map((r, idx) => {
+          const pos = idx + 1;
+          const gap = leaderChars - r.chars;
+          return (
+            <li
+              key={r.id}
+              ref={(el) => {
+                if (el) rowRefs.current.set(r.id, el);
+                else rowRefs.current.delete(r.id);
+              }}
+              className="flex items-center gap-3 rounded-lg border border-white/5 bg-black/30 px-3 py-2"
+              style={{ willChange: reducedMotion ? 'auto' : 'transform' }}
+            >
+              <span
+                className="font-speed w-5 shrink-0 text-center text-base"
+                style={{ color: r.errored ? 'var(--text-subtle)' : r.color }}
+              >
+                {r.errored ? '—' : pos}
+              </span>
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ background: r.color, boxShadow: r.errored ? 'none' : `0 0 8px ${r.color}88` }}
+                aria-hidden
+              />
+              <span className="flex min-w-0 flex-1 flex-col leading-tight">
+                <span className="flex items-center gap-1.5 truncate text-sm text-[var(--text)]">
+                  {r.label}
+                  {r.done && !r.errored && (
+                    <svg viewBox="0 0 24 24" className="h-3 w-3 shrink-0 text-[var(--text-muted)]" fill="currentColor" aria-label="finished">
+                      <path d="M5 3v18h2v-7h12V3H5zm2 2h8v3H7V5zm0 5h10v2H7v-2z" />
+                    </svg>
+                  )}
+                </span>
+                <span className="truncate text-[11px] text-[var(--text-muted)]" title={r.sublabel}>
+                  {r.sublabel}
+                </span>
+              </span>
+              <span className="shrink-0 text-right">
+                <span className="font-speed block text-[15px] text-[var(--text)]">
+                  {r.errored
+                    ? 'DNF'
+                    : r.done && r.finalOutputTokens != null
+                      ? `${compact(r.finalOutputTokens)} tok`
+                      : `${compact(r.chars)} ch`}
+                </span>
+                <span className="block font-mono text-[10px] tabular-nums text-[var(--text-muted)]">
+                  {r.errored ? '' : pos === 1 ? 'most output' : `-${compact(gap)} ch`}
+                </span>
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+export default StandingsTicker;

--- a/components/main/WinnerPodium.tsx
+++ b/components/main/WinnerPodium.tsx
@@ -1,0 +1,258 @@
+// components/main/WinnerPodium.tsx
+//
+// The decisive, celebratory finish the app was missing. One unified podium ranked by a
+// CHAMPION metric (defaulting to whatever the race mode actually rewards), plus two named
+// sub-awards: "Pole" (quickest first token) and "Fastest Lap" (highest sustained tok/s).
+//
+// Everything is computed from the authoritative provider-reported CompletionMetrics so the
+// climax never contradicts the numbers.
+
+import React, { useMemo, useState } from 'react';
+import GlassCard from '../layout/GlassCard';
+import { ResultState } from './ResultsDisplay';
+import type { RaceMode } from '../sidebar/RaceSettings';
+import { getProviderColor } from '../../utils/providerColors';
+import { getProviderById } from '../../utils/providers';
+
+type ChampMetric = 'total' | 'ttft' | 'tps' | 'tokens';
+
+interface WinnerPodiumProps {
+  results: ResultState[];
+  mode: RaceMode;
+  reducedMotion?: boolean;
+}
+
+const METRICS: { id: ChampMetric; label: string; unit: string; lowerIsBetter: boolean }[] = [
+  { id: 'total', label: 'Fastest finish', unit: 'ms', lowerIsBetter: true },
+  { id: 'ttft', label: 'Quickest first token', unit: 'ms', lowerIsBetter: true },
+  { id: 'tps', label: 'Highest throughput', unit: 'tok/s', lowerIsBetter: false },
+  { id: 'tokens', label: 'Most output', unit: 'tok', lowerIsBetter: false },
+];
+
+const DEFAULT_METRIC_BY_MODE: Record<RaceMode, ChampMetric> = {
+  drag: 'total',
+  token_limit: 'total',
+  time_limit: 'tokens',
+  free_for_all: 'tps',
+};
+
+function total(r: ResultState): number | null {
+  const m = r.metrics;
+  if (!m || !m.finishTime || !m.startTime) return null;
+  return m.finishTime - m.startTime;
+}
+function ttft(r: ResultState): number | null {
+  const m = r.metrics;
+  if (!m || !m.firstTokenTime || !m.startTime) return null;
+  return m.firstTokenTime - m.startTime;
+}
+function tps(r: ResultState): number | null {
+  const m = r.metrics;
+  if (!m || !m.finishTime || !m.firstTokenTime) return null;
+  const sec = (m.finishTime - m.firstTokenTime) / 1000;
+  // Ignore degenerate sub-150ms windows: a provider that buffers then flushes its whole
+  // answer at once would otherwise post thousands of "tok/s" and steal Fastest Lap.
+  if (sec < 0.15) return null;
+  const out = typeof m.outputTokens === 'number' ? m.outputTokens : m.tokenCount;
+  return out / sec;
+}
+function tokens(r: ResultState): number | null {
+  const m = r.metrics;
+  if (!m) return null;
+  return typeof m.outputTokens === 'number' ? m.outputTokens : m.tokenCount;
+}
+
+const METRIC_FN: Record<ChampMetric, (r: ResultState) => number | null> = {
+  total,
+  ttft,
+  tps,
+  tokens,
+};
+
+function fmt(metric: ChampMetric, v: number): string {
+  if (metric === 'total' || metric === 'ttft') {
+    return v >= 1000 ? `${(v / 1000).toFixed(2)}s` : `${Math.round(v)}ms`;
+  }
+  if (metric === 'tps') return v.toFixed(1);
+  return String(Math.round(v));
+}
+
+const MEDALS = [
+  { ring: 'var(--race-gold)', label: '1st', podium: 'podium-gold' },
+  { ring: 'var(--race-silver)', label: '2nd', podium: 'podium-silver' },
+  { ring: 'var(--race-bronze)', label: '3rd', podium: 'podium-bronze' },
+];
+
+function displayName(providerId: string): string {
+  return getProviderById(providerId)?.displayName || providerId;
+}
+
+const WinnerPodium: React.FC<WinnerPodiumProps> = ({ results, mode, reducedMotion = false }) => {
+  const [metric, setMetric] = useState<ChampMetric>(DEFAULT_METRIC_BY_MODE[mode] ?? 'total');
+
+  const finished = useMemo(() => results.filter((r) => r.metrics && !r.error), [results]);
+
+  const ranked = useMemo(() => {
+    const cfg = METRICS.find((m) => m.id === metric)!;
+    const fn = METRIC_FN[metric];
+    return finished
+      .map((r) => ({ r, v: fn(r) }))
+      .filter((x): x is { r: ResultState; v: number } => x.v != null)
+      .sort((a, b) => (cfg.lowerIsBetter ? a.v - b.v : b.v - a.v));
+  }, [finished, metric]);
+
+  const pole = useMemo(() => {
+    const arr = finished
+      .map((r) => ({ r, v: ttft(r) }))
+      .filter((x): x is { r: ResultState; v: number } => x.v != null)
+      .sort((a, b) => a.v - b.v);
+    return arr[0];
+  }, [finished]);
+
+  const fastestLap = useMemo(() => {
+    const arr = finished
+      .map((r) => ({ r, v: tps(r) }))
+      .filter((x): x is { r: ResultState; v: number } => x.v != null)
+      .sort((a, b) => b.v - a.v);
+    return arr[0];
+  }, [finished]);
+
+  if (ranked.length === 0) return null;
+
+  const top3 = ranked.slice(0, 3);
+  // Visual podium order: 2nd, 1st, 3rd.
+  const order = top3.length === 3 ? [1, 0, 2] : top3.length === 2 ? [1, 0] : [0];
+  const cfg = METRICS.find((m) => m.id === metric)!;
+  const anim = reducedMotion ? '' : 'animate-fade-up';
+
+  return (
+    <GlassCard className={`relative overflow-hidden p-5 ${reducedMotion ? '' : 'animate-winner-pop'}`} glow>
+      {/* celebratory top accent */}
+      <div
+        className="absolute inset-x-0 top-0 h-[3px]"
+        style={{ background: `linear-gradient(to right, transparent, var(--race-gold), transparent)` }}
+      />
+
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-amber-300/25 to-amber-600/15 ring-1 ring-amber-400/30">
+            <svg viewBox="0 0 24 24" className={`h-5 w-5 text-amber-300 ${reducedMotion ? '' : 'animate-trophy-bounce'}`} fill="currentColor">
+              <path d="M5 4h14v3a5 5 0 0 1-4 4.9V14l2 4H7l2-4v-2.1A5 5 0 0 1 5 7V4zm-3 1h2v2a3 3 0 0 1-2-2zm18 0a3 3 0 0 1-2 2V5h2z" />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight text-white heading-tight">Winner&rsquo;s Circle</h2>
+            <p className="text-xs text-[var(--text-muted)]">
+              Champion by {cfg.label.toLowerCase()} · {finished.length} finished
+            </p>
+          </div>
+        </div>
+
+        {/* champion-metric selector */}
+        <div className="inline-flex overflow-hidden rounded-[12px] ring-1 ring-white/10" role="radiogroup" aria-label="Champion metric">
+          {METRICS.map((m) => (
+            <button
+              key={m.id}
+              role="radio"
+              aria-checked={metric === m.id}
+              onClick={() => setMetric(m.id)}
+              className={`px-2.5 py-1.5 text-[11px] font-medium transition ${
+                metric === m.id ? 'bg-white/[0.12] text-white' : 'bg-white/[0.03] text-[var(--text-muted)] hover:bg-white/[0.08]'
+              }`}
+              title={`${m.label} (${m.unit})`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* podium */}
+      <div
+        className="flex items-end justify-center gap-3 sm:gap-5"
+        role="group"
+        aria-label={`Podium: ${top3.map((e, i) => `${i + 1} ${displayName(e.r.providerName)}`).join(', ')}`}
+      >
+        {order.map((rankIdx, i) => {
+          const entry = top3[rankIdx];
+          if (!entry) return null;
+          const place = rankIdx; // 0,1,2
+          const medal = MEDALS[place];
+          const color = getProviderColor(entry.r.providerName).solid;
+          const isChamp = place === 0;
+          const heights = ['h-28 sm:h-32', 'h-20 sm:h-24', 'h-16 sm:h-20'];
+          return (
+            <div
+              key={entry.r.id}
+              className={`flex w-1/3 max-w-[220px] flex-col items-center ${anim}`}
+              style={{ animationDelay: reducedMotion ? undefined : `${i * 90}ms` }}
+            >
+              {/* model chip */}
+              <div className="mb-2 flex flex-col items-center text-center">
+                <span
+                  className="mb-1 h-2.5 w-2.5 rounded-full"
+                  style={{ background: color, boxShadow: `0 0 10px ${color}` }}
+                />
+                <span className={`truncate text-sm font-semibold ${isChamp ? 'text-white' : 'text-[var(--text)]'}`}>
+                  {displayName(entry.r.providerName)}
+                </span>
+                <span className="max-w-[140px] truncate text-[11px] text-[var(--text-muted)]" title={entry.r.modelName}>
+                  {entry.r.modelName}
+                </span>
+              </div>
+              {/* podium block */}
+              <div
+                className={`flex w-full ${heights[place]} flex-col items-center justify-start rounded-t-xl border ${medal.podium} pt-2`}
+              >
+                <span className="text-base font-bold" style={{ color: medal.ring }}>
+                  {medal.label}
+                </span>
+                <span className="font-speed mt-1 text-[16px] text-white">
+                  {fmt(metric, entry.v)}
+                </span>
+                {(metric === 'tps' || metric === 'tokens') && (
+                  <span className="text-[10px] text-[var(--text-muted)]">{cfg.unit}</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* sub-awards */}
+      <div className="mt-5 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {pole && (
+          <div className="flex items-center gap-2.5 rounded-xl border border-cyan-500/20 bg-cyan-500/5 px-3 py-2">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-cyan-300">Pole</span>
+            <span className="min-w-0 flex-1 truncate text-sm text-[var(--text)]">
+              {displayName(pole.r.providerName)}{' '}
+              <span className="text-[var(--text-muted)]">— {pole.r.modelName}</span>
+            </span>
+            <span className="shrink-0 font-mono text-sm font-semibold tabular-nums text-cyan-300">
+              {fmt('ttft', pole.v)}
+            </span>
+          </div>
+        )}
+        {fastestLap && (
+          <div className="flex items-center gap-2.5 rounded-xl border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-amber-300">Fastest Lap</span>
+            <span className="min-w-0 flex-1 truncate text-sm text-[var(--text)]">
+              {displayName(fastestLap.r.providerName)}{' '}
+              <span className="text-[var(--text-muted)]">— {fastestLap.r.modelName}</span>
+            </span>
+            <span className="shrink-0 font-mono text-sm font-semibold tabular-nums text-amber-300">
+              {fastestLap.v.toFixed(1)} tok/s
+            </span>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-3 text-center text-[11px] text-[var(--text-muted)]">
+        Ranked by measured timing. Token counts are estimated from output length unless a provider reports exact usage.
+        Switch the metric above — every race is a live measurement, not a fixed ranking.
+      </p>
+    </GlassCard>
+  );
+};
+
+export default WinnerPodium;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useCallback, useState } from 'react';
+import React, { useReducer, useCallback, useState, useRef, useEffect, useMemo } from 'react';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
 import MainLayout from '../components/layout/MainLayout';
@@ -10,10 +10,18 @@ import { CompletionMetrics } from '../utils/providerService';
 import GlassCard from '../components/layout/GlassCard';
 import CountdownOverlay from '../components/main/CountdownOverlay';
 import RaceSettings, { RaceConfig } from '../components/sidebar/RaceSettings';
+import { LaneBuffer, createLaneBuffer, pushChunk } from '../utils/raceBuffers';
+import { getProviderColor } from '../utils/providerColors';
+import { getProviderById } from '../utils/providers';
+import type { PaceLane } from '../components/main/LivePaceChart';
 
 const ResultsDisplay = dynamic(() => import('../components/main/ResultsDisplay'), { ssr: false });
 const Leaderboard = dynamic(() => import('../components/main/Leaderboard'), { ssr: false });
 const ComparisonCharts = dynamic(() => import('../components/ComparisonCharts'), { ssr: false });
+const LivePaceChart = dynamic(() => import('../components/main/LivePaceChart'), { ssr: false });
+const DragStrip = dynamic(() => import('../components/main/DragStrip'), { ssr: false });
+const StandingsTicker = dynamic(() => import('../components/main/StandingsTicker'), { ssr: false });
+const WinnerPodium = dynamic(() => import('../components/main/WinnerPodium'), { ssr: false });
 
 // --- State Management using useReducer ---
 
@@ -36,6 +44,7 @@ type AppAction =
   | { type: 'CLEAR_PROVIDER_SELECTIONS'; payload: { providerId: string } }
   | { type: 'START_COMPARISON'; payload: { providersToTest: { providerId: string; modelId: string }[] } }
   | { type: 'RECEIVE_CHUNK'; payload: { resultId: string; chunk: string } }
+  | { type: 'COMMIT_TEXT'; payload: Record<string, string> }
   | { type: 'FINISH_STREAM'; payload: { resultId: string; metrics: CompletionMetrics } }
   | { type: 'SET_ERROR'; payload: { resultId: string; error: string } }
   | { type: 'FINISH_COMPARISON' }
@@ -107,6 +116,16 @@ function appReducer(state: AppState, action: AppAction): AppState {
             : r
         ),
       };
+    case 'COMMIT_TEXT': {
+      // Batched, throttled append of streamed text deltas (off the per-token hot path).
+      const deltas = action.payload;
+      return {
+        ...state,
+        results: state.results.map(r =>
+          deltas[r.id] ? { ...r, responseText: r.responseText + deltas[r.id] } : r
+        ),
+      };
+    }
     case 'FINISH_STREAM':
       return {
         ...state,
@@ -145,6 +164,18 @@ function appReducer(state: AppState, action: AppAction): AppState {
   }
 }
 
+// --- Demo race (a separate "test" — lets visitors without API keys watch the viz run) ---
+// Real provider IDs so colors/logos resolve; the "· demo" suffix marks them as simulated.
+const DEMO_LANES: { providerId: string; modelId: string; ttft: number; cps: number; total: number }[] = [
+  { providerId: 'cerebras', modelId: 'llama-3.1-8b · demo', ttft: 190, cps: 820, total: 1300 },
+  { providerId: 'groq', modelId: 'llama-3.3-70b · demo', ttft: 250, cps: 680, total: 1450 },
+  { providerId: 'openai', modelId: 'gpt-4o-mini · demo', ttft: 520, cps: 360, total: 1250 },
+  { providerId: 'anthropic', modelId: 'claude-haiku · demo', ttft: 640, cps: 320, total: 1600 },
+];
+const DEMO_SAMPLE =
+  "Here's the quick read on inference speed. Three things matter: how fast the first token arrives, how steadily the model streams after that, and how much it ultimately produces. A model can launch quickly yet stream slowly, or start late and then sprint to the line. Watching them race side by side makes those trade-offs obvious in a way a single number never could. ";
+const DEMO_LONG = DEMO_SAMPLE.repeat(10);
+
 // --- Main Component ---
 
 export default function Home() {
@@ -152,10 +183,70 @@ export default function Home() {
   const [activeTab, setActiveTab] = useState<'results' | 'charts'>('results');
   const [hideFailed, setHideFailed] = useState(false);
   const [force, setForce] = useState<{ version: number; collapsed: boolean }>({ version: 0, collapsed: false });
+
+  // --- Live race engine (off the React commit path) ---
+  const goTimeRef = useRef<number>(0);
+  const laneBuffersRef = useRef<Record<string, LaneBuffer>>({});
+  const pendingTextRef = useRef<Record<string, string>>({});
+  const flushTimerRef = useRef<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [normalize, setNormalize] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  const [raceView, setRaceView] = useState<'strip' | 'telemetry'>('strip');
+
+  // Cleanup on unmount: clear the flush timer and cancel any in-flight streams.
+  useEffect(() => {
+    return () => {
+      if (flushTimerRef.current != null) clearInterval(flushTimerRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(mq.matches);
+    const handler = () => setReducedMotion(mq.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    abortRef.current?.abort();
+    if (flushTimerRef.current != null) {
+      clearInterval(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    laneBuffersRef.current = {};
+    pendingTextRef.current = {};
+    setAnnouncement('');
+    dispatch({ type: 'RESET_RACE' });
+  }, []);
+
+  // Per-lane meta for the pace chart + standings. Keyed on a stable signature (ids +
+  // providers + models) so streamed-text commits don't churn the array identity and force
+  // the chart/strip to re-render mid-race.
+  const laneSig = state.results.map((r) => `${r.id}:${r.providerName}`).join('|');
+  const paceLanes = useMemo<PaceLane[]>(
+    () =>
+      state.results.map((r) => ({
+        id: r.id,
+        label: getProviderById(r.providerName)?.displayName || r.providerName,
+        sublabel: r.modelName,
+        color: getProviderColor(r.providerName).solid,
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [laneSig]
+  );
+  const showStage =
+    state.results.length > 0 && (state.raceState === 'racing' || state.raceState === 'finished');
+
   const startDisabled =
     !state.selectedPairs.some(
       (p) => state.enabledProviders[p.providerId] !== false && !!state.apiKeys[p.providerId] && !!p.modelId
-    ) || state.raceState === 'countingDown';
+    ) || state.raceState === 'countingDown' || state.raceState === 'racing';
 
   const handleRunComparison = useCallback(async () => {
     // If the user selected specific provider+model pairs, use those.
@@ -168,8 +259,45 @@ export default function Home() {
       return;
     }
     const providersToTest = selected;
-    // Stage lanes first so users see lanes before the countdown
+    // Cancel any prior in-flight streams and open a fresh abort scope for this race.
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+    const signal = abortRef.current.signal;
+    // Reset the live race engine, then stage lanes before the countdown.
+    const initialBuffers: Record<string, LaneBuffer> = {};
+    for (const p of providersToTest) {
+      const id = `${p.providerId}-${p.modelId}`;
+      initialBuffers[id] = createLaneBuffer(id);
+    }
+    laneBuffersRef.current = initialBuffers;
+    pendingTextRef.current = {};
     dispatch({ type: 'START_COMPARISON', payload: { providersToTest } });
+
+    // Throttled committer: streamed text lands in refs on the hot path and is flushed to
+    // React state ~11x/sec, so we never re-render the whole results array per token.
+    const flushLane = (id: string) => {
+      const t = pendingTextRef.current[id];
+      if (t) {
+        delete pendingTextRef.current[id];
+        dispatch({ type: 'COMMIT_TEXT', payload: { [id]: t } });
+      }
+    };
+    const startFlush = () => {
+      if (flushTimerRef.current != null) return;
+      flushTimerRef.current = window.setInterval(() => {
+        const pending = pendingTextRef.current;
+        if (Object.keys(pending).length) {
+          pendingTextRef.current = {};
+          dispatch({ type: 'COMMIT_TEXT', payload: pending });
+        }
+      }, 90);
+    };
+    const stopFlush = () => {
+      if (flushTimerRef.current != null) {
+        clearInterval(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+    };
 
     // Respect reduced motion
     const reduceMotion = typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -192,12 +320,20 @@ export default function Home() {
     // Get race config and prepare settings
     const { mode, tokenLimit, timeLimit, modelSettings } = state.raceConfig;
     const raceStartTime = Date.now();
+    // Single shared "Go!" instant — the fair cross-model baseline for the pace chart.
+    goTimeRef.current = performance.now();
+    setAnnouncement(
+      `Race started. ${providersToTest.length} ${providersToTest.length === 1 ? 'model' : 'models'} launching.`
+    );
+    startFlush();
 
     await Promise.all(
       providersToTest.map(async (p) => {
         const resultId = `${p.providerId}-${p.modelId}`;
         const apiKey = state.apiKeys[p.providerId];
         if (!apiKey) {
+          const buf = laneBuffersRef.current[resultId];
+          if (buf) { buf.errored = true; buf.done = true; }
           dispatch({ type: 'SET_ERROR', payload: { resultId, error: 'API Key not set' } });
           return;
         }
@@ -208,61 +344,212 @@ export default function Home() {
             effectiveSettings.reasoningEffort = undefined;
           }
 
-          const stream = streamCompletion(p.providerId, state.prompt, p.modelId, apiKey, effectiveSettings);
+          const stream = streamCompletion(p.providerId, state.prompt, p.modelId, apiKey, effectiveSettings, signal);
           let sawMetrics = false;
           let tokenCount = 0;
 
           for await (const result of stream) {
-            // Check race mode limits
-            if (mode === 'token_limit' && tokenLimit && tokenCount >= tokenLimit) {
-              // Token limit reached - finish early
-              break;
-            }
-            if (mode === 'time_limit' && timeLimit) {
-              const elapsed = (Date.now() - raceStartTime) / 1000;
-              if (elapsed >= timeLimit) {
-                // Time limit reached - finish early
-                break;
-              }
-            }
-
             if (result.type === 'chunk') {
               tokenCount++;
-              dispatch({ type: 'RECEIVE_CHUNK', payload: { resultId, chunk: result.content } });
+              const tNow = performance.now() - goTimeRef.current;
+              const buf = laneBuffersRef.current[resultId];
+              if (buf) pushChunk(buf, result.content, tNow);
+              pendingTextRef.current[resultId] = (pendingTextRef.current[resultId] || '') + result.content;
+              // Enforce race-mode limits AFTER recording the chunk, and only on chunks — so
+              // we never break before consuming the final metrics event.
+              if (mode === 'token_limit' && tokenLimit && tokenCount >= tokenLimit) break;
+              if (mode === 'time_limit' && timeLimit && (Date.now() - raceStartTime) / 1000 >= timeLimit) break;
             } else if (result.type === 'metrics') {
+              const buf = laneBuffersRef.current[resultId];
+              if (buf) {
+                buf.done = true;
+                buf.finalOutputTokens =
+                  typeof result.data.outputTokens === 'number' ? result.data.outputTokens : null;
+              }
+              flushLane(resultId);
               dispatch({ type: 'FINISH_STREAM', payload: { resultId, metrics: result.data } });
+              setAnnouncement(`${getProviderById(p.providerId)?.displayName || p.providerId} finished.`);
               sawMetrics = true;
             }
           }
           // If the stream closed without emitting metrics (e.g., due to limits), create synthetic metrics
           if (!sawMetrics) {
             if (mode === 'token_limit' || mode === 'time_limit') {
-              // For limited races, we create metrics based on what we collected
+              // For limited races, synthesize metrics from what we collected — but use the
+              // REAL client-observed first-token time instead of a hardcoded +100ms.
               const finishTime = Date.now();
+              const buf = laneBuffersRef.current[resultId];
+              if (buf) buf.done = true;
+              flushLane(resultId);
               dispatch({
                 type: 'FINISH_STREAM',
                 payload: {
                   resultId,
                   metrics: {
                     startTime: raceStartTime,
-                    firstTokenTime: raceStartTime + 100, // approximate
+                    // Real client-observed first token — or omit entirely if the model never
+                    // streamed one, so it can't win Pole with a fake 0ms TTFT.
+                    firstTokenTime:
+                      buf && buf.firstTokenT != null ? raceStartTime + Math.round(buf.firstTokenT) : undefined,
                     finishTime,
                     tokenCount,
                     outputTokens: tokenCount,
                   },
                 },
               });
+              setAnnouncement(`${getProviderById(p.providerId)?.displayName || p.providerId} finished.`);
             } else {
+              const buf = laneBuffersRef.current[resultId];
+              if (buf) { buf.errored = true; buf.done = true; }
+              flushLane(resultId);
               dispatch({ type: 'SET_ERROR', payload: { resultId, error: 'Stream ended without metrics' } });
             }
           }
         } catch (e: any) {
+          const buf = laneBuffersRef.current[resultId];
+          if (buf) { buf.errored = true; buf.done = true; }
+          flushLane(resultId);
           dispatch({ type: 'SET_ERROR', payload: { resultId, error: e.message } });
         }
       })
     );
+    // Final flush + stop the throttled committer so the transcripts are complete.
+    stopFlush();
+    const remaining = pendingTextRef.current;
+    if (Object.keys(remaining).length) {
+      pendingTextRef.current = {};
+      dispatch({ type: 'COMMIT_TEXT', payload: remaining });
+    }
+    setAnnouncement('Race finished. The Winner’s Circle is ready below the pace chart.');
     dispatch({ type: 'FINISH_COMPARISON' });
   }, [state.prompt, state.apiKeys, state.selectedPairs, state.enabledProviders, state.raceConfig]);
+
+  // Simulated test race — no API keys, no network. Drives the exact same render path
+  // (buffers, countdown, podium) with synthetic streams so the visualization can be tried.
+  const handleRunDemo = useCallback(async () => {
+    if (state.raceState === 'racing' || state.raceState === 'countingDown') return;
+    const pairs = DEMO_LANES.map((d) => ({ providerId: d.providerId, modelId: d.modelId }));
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+    const signal = abortRef.current.signal;
+
+    const initialBuffers: Record<string, LaneBuffer> = {};
+    for (const p of pairs) {
+      const id = `${p.providerId}-${p.modelId}`;
+      initialBuffers[id] = createLaneBuffer(id);
+    }
+    laneBuffersRef.current = initialBuffers;
+    pendingTextRef.current = {};
+    dispatch({ type: 'START_COMPARISON', payload: { providersToTest: pairs } });
+
+    const flushLane = (id: string) => {
+      const t = pendingTextRef.current[id];
+      if (t) {
+        delete pendingTextRef.current[id];
+        dispatch({ type: 'COMMIT_TEXT', payload: { [id]: t } });
+      }
+    };
+    const startFlush = () => {
+      if (flushTimerRef.current != null) return;
+      flushTimerRef.current = window.setInterval(() => {
+        const pending = pendingTextRef.current;
+        if (Object.keys(pending).length) {
+          pendingTextRef.current = {};
+          dispatch({ type: 'COMMIT_TEXT', payload: pending });
+        }
+      }, 90);
+    };
+    const stopFlush = () => {
+      if (flushTimerRef.current != null) {
+        clearInterval(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+    };
+
+    const reduceMotion =
+      typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    if (reduceMotion) {
+      dispatch({ type: 'SET_RACE_STATE', payload: 'racing' });
+      dispatch({ type: 'SET_COUNTDOWN', payload: null });
+    } else {
+      dispatch({ type: 'SET_RACE_STATE', payload: 'countingDown' });
+      for (const val of [3, 2, 1] as const) {
+        dispatch({ type: 'SET_COUNTDOWN', payload: val });
+        await delay(700);
+      }
+      dispatch({ type: 'SET_COUNTDOWN', payload: 'Go!' });
+      await delay(300);
+      dispatch({ type: 'SET_RACE_STATE', payload: 'racing' });
+      dispatch({ type: 'SET_COUNTDOWN', payload: null });
+    }
+
+    const raceStartTime = Date.now();
+    goTimeRef.current = performance.now();
+    setAnnouncement('Demo race started. 4 simulated models launching.');
+    startFlush();
+
+    await Promise.all(
+      DEMO_LANES.map(async (d) => {
+        const resultId = `${d.providerId}-${d.modelId}`;
+        try {
+          await delay(d.ttft);
+          const perTick = Math.max(2, Math.round(d.cps * 0.08));
+          let produced = 0;
+          while (produced < d.total) {
+            if (signal.aborted) throw new Error('aborted');
+            const take = Math.min(perTick, d.total - produced);
+            const start = produced % DEMO_LONG.length;
+            let text = DEMO_LONG.slice(start, start + take);
+            if (text.length < take) text += DEMO_LONG.slice(0, take - text.length);
+            produced += take;
+            const tNow = performance.now() - goTimeRef.current;
+            const buf = laneBuffersRef.current[resultId];
+            if (buf) pushChunk(buf, text, tNow);
+            pendingTextRef.current[resultId] = (pendingTextRef.current[resultId] || '') + text;
+            await delay(70 + Math.random() * 50);
+          }
+          const finishTime = Date.now();
+          const buf = laneBuffersRef.current[resultId];
+          if (buf) {
+            buf.done = true;
+            buf.finalOutputTokens = Math.round(d.total / 4);
+          }
+          flushLane(resultId);
+          dispatch({
+            type: 'FINISH_STREAM',
+            payload: {
+              resultId,
+              metrics: {
+                startTime: raceStartTime,
+                firstTokenTime: raceStartTime + d.ttft,
+                finishTime,
+                tokenCount: Math.round(d.total / 4),
+                outputTokens: Math.round(d.total / 4),
+              },
+            },
+          });
+          setAnnouncement(`${getProviderById(d.providerId)?.displayName || d.providerId} finished.`);
+        } catch {
+          const buf = laneBuffersRef.current[resultId];
+          if (buf) {
+            buf.errored = true;
+            buf.done = true;
+          }
+          flushLane(resultId);
+        }
+      })
+    );
+    if (signal.aborted) return;
+    stopFlush();
+    const remaining = pendingTextRef.current;
+    if (Object.keys(remaining).length) {
+      pendingTextRef.current = {};
+      dispatch({ type: 'COMMIT_TEXT', payload: remaining });
+    }
+    setAnnouncement('Demo race finished. The Winner’s Circle is ready below.');
+    dispatch({ type: 'FINISH_COMPARISON' });
+  }, [state.raceState]);
 
   return (
     <>
@@ -327,11 +614,11 @@ export default function Home() {
               onPromptChange={(p) => dispatch({ type: 'SET_PROMPT', payload: p })}
               onSubmit={handleRunComparison}
               isLoading={state.isLoading || state.raceState === 'countingDown'}
-              onReset={() => dispatch({ type: 'RESET_RACE' })}
+              onReset={handleReset}
               disabled={
                 !state.selectedPairs.some(
                   (p) => state.enabledProviders[p.providerId] !== false && !!state.apiKeys[p.providerId] && !!p.modelId
-                ) || state.raceState === 'countingDown'
+                ) || state.raceState === 'countingDown' || state.raceState === 'racing'
               }
             />
             {/* Race Settings */}
@@ -390,7 +677,11 @@ export default function Home() {
               AI Drag Racing compares model behavior under the same prompt, selected settings, and local browser
               session. Time to first token shows how quickly a provider starts responding. Total response time shows
               how long the full answer takes. Tokens per second is useful for longer generations because a model can
-              start quickly but still stream slowly after the first token appears.
+              start quickly but still stream slowly after the first token appears. The live pace chart plots
+              characters streamed against a shared client clock, so the curve faithfully reflects what your browser
+              received; chunk boundaries and edge-network timing vary by provider. Token counts are estimated from
+              output length (about four characters per token) except where a provider reports exact usage, so treat
+              them as approximate.
             </p>
             <p>
               Treat every run as a live measurement, not a permanent leaderboard. Network route, provider load,
@@ -446,11 +737,24 @@ export default function Home() {
                   </span>
                 </button>
                 <button
-                  onClick={() => dispatch({ type: 'RESET_RACE' })}
+                  onClick={handleReset}
                   className="race-reset-button press-scale"
                   disabled={state.isLoading || state.raceState === 'countingDown'}
                 >
                   Reset
+                </button>
+                <button
+                  onClick={handleRunDemo}
+                  className="race-tool-button hidden sm:inline-flex"
+                  disabled={state.raceState === 'racing' || state.raceState === 'countingDown'}
+                  title="Run a simulated test race — no API key needed"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M9 3h6M10 3v6l-5.5 9.2A2 2 0 0 0 6.2 21h11.6a2 2 0 0 0 1.7-2.8L14 9V3" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    Demo
+                  </span>
                 </button>
                 <button
                   onClick={() => setHideFailed((v) => !v)}
@@ -476,10 +780,108 @@ export default function Home() {
               </div>
             </div>
           </div>
+          {/* Live race announcements for assistive technology */}
+          <div className="sr-only" role="status" aria-live="polite">{announcement}</div>
+
           {/* Content */}
           {activeTab === 'results' && (
             <>
-              <ResultsDisplay results={state.results} hideFailed={hideFailed} force={force} />
+              {showStage && (
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+                  <GlassCard className="p-4" spotlight={false}>
+                    <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        {/* Strip (arcade) vs Telemetry (pace chart) view toggle */}
+                        <div className="inline-flex overflow-hidden rounded-[12px] ring-1 ring-white/10" role="group" aria-label="Race view">
+                          <button
+                            type="button"
+                            onClick={() => setRaceView('strip')}
+                            aria-pressed={raceView === 'strip'}
+                            className={`px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider transition ${raceView === 'strip' ? 'bg-white/[0.12] text-white' : 'bg-white/[0.03] text-[var(--text-muted)] hover:bg-white/[0.08]'}`}
+                          >
+                            <span aria-hidden>🏁 </span>Strip
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setRaceView('telemetry')}
+                            aria-pressed={raceView === 'telemetry'}
+                            className={`px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider transition ${raceView === 'telemetry' ? 'bg-white/[0.12] text-white' : 'bg-white/[0.03] text-[var(--text-muted)] hover:bg-white/[0.08]'}`}
+                          >
+                            Telemetry
+                          </button>
+                        </div>
+                        {state.raceState === 'racing' && (
+                          <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--accent-muted)] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[var(--accent-light)]">
+                            <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent-light)] animate-pulse" />
+                            Live
+                          </span>
+                        )}
+                      </div>
+                      {raceView === 'telemetry' && (
+                        <div className="flex items-center gap-3">
+                          <span className="hidden text-[10px] text-[var(--text-muted)] sm:inline">
+                            X: seconds since Go · Y: characters streamed
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => setNormalize((v) => !v)}
+                            aria-pressed={normalize}
+                            className="btn-ghost text-[11px]"
+                            title="Toggle the Y scale between absolute characters and percent of the most output so far"
+                          >
+                            {normalize ? 'Scale: % of most output' : 'Scale: absolute'}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                    {raceView === 'strip' ? (
+                      <DragStrip
+                        lanes={paceLanes}
+                        buffersRef={laneBuffersRef}
+                        goTimeRef={goTimeRef}
+                        running={state.raceState === 'racing'}
+                        reducedMotion={reducedMotion}
+                      />
+                    ) : (
+                      <>
+                        <LivePaceChart
+                          lanes={paceLanes}
+                          buffersRef={laneBuffersRef}
+                          goTimeRef={goTimeRef}
+                          running={state.raceState === 'racing'}
+                          reducedMotion={reducedMotion}
+                          normalize={normalize}
+                        />
+                        <div className="mt-2 flex max-h-[68px] flex-wrap gap-x-4 gap-y-1 overflow-y-auto scrollbar-none">
+                          {paceLanes.map((l) => (
+                            <span key={l.id} className="inline-flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                              <span className="h-2 w-2 rounded-full" style={{ background: l.color }} />
+                              <span className="max-w-[160px] truncate" title={`${l.label} — ${l.sublabel}`}>
+                                {l.label}
+                              </span>
+                            </span>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </GlassCard>
+                  <GlassCard className="flex flex-col p-3" spotlight={false}>
+                    <h3 className="mb-2 px-1 text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+                      Standings
+                    </h3>
+                    <StandingsTicker
+                      lanes={paceLanes}
+                      buffersRef={laneBuffersRef}
+                      running={state.raceState === 'racing'}
+                      reducedMotion={reducedMotion}
+                    />
+                  </GlassCard>
+                </div>
+              )}
+              {state.raceState === 'finished' && (
+                <WinnerPodium results={state.results} mode={state.raceConfig.mode} reducedMotion={reducedMotion} />
+              )}
+              <ResultsDisplay results={state.results} hideFailed={hideFailed} force={force} compact={showStage} onDemo={handleRunDemo} />
               {state.results.length > 0 && <Leaderboard results={state.results} />}
             </>
           )}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -829,6 +829,27 @@
   animation: trophy-bounce 2s ease-in-out infinite;
 }
 
+/* Winner podium reveal */
+@keyframes winner-pop {
+  0% {
+    transform: scale(0.98) translateY(8px);
+    opacity: 0;
+  }
+
+  60% {
+    transform: scale(1.01) translateY(0);
+  }
+
+  100% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+}
+
+.animate-winner-pop {
+  animation: winner-pop 0.5s var(--ease-out-back) forwards;
+}
+
 .animate-fade-up {
   animation: fade-up 0.5s var(--ease-out-expo) forwards;
 }
@@ -1102,4 +1123,120 @@
 
 .press-scale:active {
   transform: scale(0.98);
+}
+
+/* ============================================================
+   DRAG STRIP — arcade racing view
+   ============================================================ */
+
+/* Italic, tight "speed" numerals for racing readouts */
+.font-speed {
+  font-style: italic;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Asphalt lane surface with a faint aggregate texture */
+.asphalt {
+  background-color: #121419;
+  background-image:
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.02) 0 2px, transparent 2px 9px),
+    radial-gradient(rgba(255, 255, 255, 0.045) 0.5px, transparent 0.5px);
+  background-size: auto, 7px 7px;
+}
+
+/* Checkerboard (finish line + flags) */
+.checker-bg {
+  background-image:
+    linear-gradient(45deg, rgba(255, 255, 255, 0.88) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.88) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.88) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.88) 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+}
+
+/* Dashed lane centerline */
+.lane-dashes {
+  background-image: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.22) 0 14px, transparent 14px 30px);
+}
+
+/* Engine flame behind a launched dragster */
+@keyframes flame-flicker {
+  0%, 100% { transform: scaleX(1) scaleY(1); opacity: 0.92; }
+  50% { transform: scaleX(1.35) scaleY(0.8); opacity: 0.6; }
+}
+
+.car-flame {
+  animation: flame-flicker 0.1s linear infinite;
+  transform-origin: right center;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.dragster[data-running="true"] .car-flame {
+  opacity: 1;
+}
+
+.leader-crown {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.dragster[data-leader="true"] .leader-crown {
+  opacity: 1;
+}
+
+.dragster[data-running="true"] {
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.5));
+}
+
+/* Burnout / launch smoke puff */
+@keyframes smoke-puff {
+  0% { transform: scale(0.4); opacity: 0.55; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+
+.smoke-puff {
+  animation: smoke-puff 0.7s ease-out forwards;
+}
+
+/* Waving checkered flag on finish */
+@keyframes flag-wave {
+  0%, 100% { transform: rotate(-5deg) skewX(-2deg); }
+  50% { transform: rotate(5deg) skewX(2deg); }
+}
+
+.flag-wave {
+  animation: flag-wave 0.45s ease-in-out infinite;
+  transform-origin: left center;
+}
+
+/* Speed streak shimmer */
+@keyframes streak-shift {
+  0% { background-position: 0 0; }
+  100% { background-position: -24px 0; }
+}
+
+.speed-streak {
+  background: repeating-linear-gradient(90deg, currentColor 0 6px, transparent 6px 12px);
+  animation: streak-shift 0.18s linear infinite;
+}
+
+/* ============================================================
+   Reduced-motion: neutralize ALL animation/transition globally
+   (the JS paths already branch; this covers always-on CSS like
+   the Live pill, spinners, status pulses, and the arcade FX).
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -14,7 +14,8 @@ export async function* streamCompletion(
   prompt: string,
   model: string,
   apiKey: string,
-  settings?: ModelSettings
+  settings?: ModelSettings,
+  signal?: AbortSignal
 ): AsyncGenerator<CompletionResult> {
 
   const response = await fetch(`/api/providers/${providerId}/completions`, {
@@ -23,6 +24,7 @@ export async function* streamCompletion(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ prompt, model, apiKey, settings }),
+    signal,
   });
 
   if (!response.ok || !response.body) {

--- a/utils/providerColors.ts
+++ b/utils/providerColors.ts
@@ -1,18 +1,94 @@
 // utils/providerColors.ts
-// OLED palette mapping (no purple). Soft colors ~65% opacity for glass charts.
-export const providerColorMap: Record<string, { solid: string; soft: string }> = {
-  // Charts order reference: cyan, peach, emerald, info blue, amber, rose
-  openai:    { solid: '#22D3EE', soft: 'rgba(34,211,238,0.65)' },  // cyan
-  groq:      { solid: '#FFB86B', soft: 'rgba(255,184,107,0.65)' }, // peach
-  anthropic: { solid: '#34D399', soft: 'rgba(52,211,153,0.65)' },  // emerald
-  google:    { solid: '#60A5FA', soft: 'rgba(96,165,250,0.65)' },  // info blue
-  cohere:    { solid: '#F59E0B', soft: 'rgba(245,158,11,0.65)' },  // amber
-  mistral:   { solid: '#FB7185', soft: 'rgba(251,113,133,0.65)' }, // rose
-  openrouter:{ solid: '#22D3EE', soft: 'rgba(34,211,238,0.65)' },  // default cyan
-  bedrock:   { solid: '#34D399', soft: 'rgba(52,211,153,0.65)' },  // emerald
-  together:  { solid: '#FFB86B', soft: 'rgba(255,184,107,0.65)' }, // peach
+// Per-provider data-ink identity for the OLED (#090a0c) theme.
+//
+// Goals:
+//  - Every one of the 18 providers in utils/providers.ts gets a UNIQUE, memorable hue
+//    so lanes, the live pace chart, standings, podium and bar charts all agree.
+//  - All hues are tuned for >= ~4.5:1 contrast on near-black and kept clear of the
+//    violet/indigo band (the source file's longstanding "no purple" rule).
+//  - Any future / unknown provider id gets a STABLE distinct color via a hash fallback
+//    instead of collapsing to a single shared cyan.
+//
+// `solid` = full-strength line / dot / glow color.
+// `soft`  = same hue at 0.65 alpha for chart fills and tints.
+
+export interface ProviderColor {
+  solid: string;
+  soft: string;
+}
+
+// Hand-tuned, mutually-distinct palette (no purple/violet/indigo).
+const PROVIDER_SOLIDS: Record<string, string> = {
+  openai: '#12D7C6', // teal
+  anthropic: '#F2A35E', // clay / tan
+  google: '#4F9DF9', // blue
+  groq: '#FF6F5E', // coral
+  fireworks: '#FF4FA3', // hot pink
+  together: '#2BD4A0', // jade
+  azure: '#59C2F7', // sky
+  openrouter: '#9AA4B2', // slate
+  bedrock: '#FF9F40', // orange
+  cohere: '#EC74C9', // orchid pink
+  mistral: '#FBBF24', // amber
+  perplexity: '#22D3EE', // cyan
+  xai: '#E6E8EB', // near-white
+  deepseek: '#6E8BFF', // cornflower blue
+  ai21: '#B6E84F', // lime
+  cerebras: '#FF7A45', // burnt orange
+  moonshot: '#7FE0C0', // mint
+  zhipu: '#5BD66E', // green
 };
 
-export function getProviderColor(providerId: string) {
-  return providerColorMap[providerId] || { solid: '#38bdf8', soft: 'rgba(56,189,248,0.7)' }; // default cyan
+function hexToSoft(hex: string, alpha = 0.65): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
+
+// Deterministic fallback: stable hue per id, nudged out of the violet/indigo band
+// so unknown providers stay on-brand and never collide on a single default color.
+function hashHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = (h * 31 + id.charCodeAt(i)) % 360;
+  }
+  // Push hues out of 255..300 (violet/indigo) to honor the "no purple" rule.
+  if (h >= 255 && h <= 300) h = (h + 75) % 360;
+  return h;
+}
+
+function hslToHex(hh: number, s: number, l: number): string {
+  const a = (s * Math.min(l, 1 - l)) / 100;
+  const f = (n: number) => {
+    const k = (n + hh / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+const cache = new Map<string, ProviderColor>();
+
+export function getProviderColor(providerId: string): ProviderColor {
+  const key = providerId || 'unknown';
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  let solid = PROVIDER_SOLIDS[key];
+  if (!solid) {
+    // Stable, OLED-friendly fallback.
+    solid = hslToHex(hashHue(key), 78, 0.66);
+  }
+  const color: ProviderColor = { solid, soft: hexToSoft(solid) };
+  cache.set(key, color);
+  return color;
+}
+
+// Back-compat alias (some modules referenced the raw map historically).
+export const providerColorMap: Record<string, ProviderColor> = Object.fromEntries(
+  Object.entries(PROVIDER_SOLIDS).map(([id, solid]) => [id, { solid, soft: hexToSoft(solid) }])
+);

--- a/utils/raceBuffers.ts
+++ b/utils/raceBuffers.ts
@@ -1,0 +1,102 @@
+// utils/raceBuffers.ts
+//
+// The live "race engine" data contract.
+//
+// During a race we must NOT re-render React on every streamed chunk (that re-maps the
+// whole results array per token -> ~100 renders/sec with many lanes). Instead each lane
+// accumulates into a plain mutable LaneBuffer held in a ref, the Pace Chart + Standings
+// read those buffers from a single requestAnimationFrame loop, and React state is only
+// committed on a throttled cadence (for the readable transcripts).
+//
+// Truthfulness rules baked into the shape:
+//  - X is ELAPSED ms since the single shared client-side "Go!" instant (the only fair
+//    cross-model baseline; all lanes launch from the same dispatch).
+//  - Y is CUMULATIVE CHARACTERS streamed. Characters (not SSE chunk count) because chunk
+//    granularity varies wildly per provider; characters is a smooth, fair output proxy.
+//    Authoritative TOKEN counts come separately from provider-reported CompletionMetrics.
+
+export interface LaneSample {
+  t: number; // ms since "Go!"
+  chars: number; // cumulative characters streamed at time t
+}
+
+export interface LaneBuffer {
+  id: string;
+  samples: LaneSample[]; // downsampled, strictly increasing t
+  chars: number; // running total characters
+  firstTokenT: number | null; // client-observed ms-since-Go of first streamed chunk
+  lastT: number; // ms-since-Go of most recent activity
+  done: boolean;
+  errored: boolean;
+  finalOutputTokens: number | null; // provider-reported output tokens, when available
+}
+
+// Minimum spacing between retained samples. Keeps the polyline bounded for long
+// generations (a 60s race -> ~750 points/lane) while staying smooth to the eye.
+export const SAMPLE_MS = 60;
+
+export function createLaneBuffer(id: string): LaneBuffer {
+  return {
+    id,
+    samples: [],
+    chars: 0,
+    firstTokenT: null,
+    lastT: 0,
+    done: false,
+    errored: false,
+    finalOutputTokens: null,
+  };
+}
+
+// Record one streamed chunk. `tNow` is performance.now() - goTime (ms since "Go!").
+export function pushChunk(buf: LaneBuffer, content: string, tNow: number): void {
+  buf.chars += content.length;
+  if (buf.firstTokenT == null) {
+    buf.firstTokenT = tNow;
+    // Anchor the line at the origin so the launch (idle until first token) reads as
+    // horizontal travel before the climb begins.
+    if (buf.samples.length === 0) buf.samples.push({ t: tNow, chars: 0 });
+    buf.samples.push({ t: tNow, chars: buf.chars });
+    buf.lastT = tNow;
+    return;
+  }
+  const last = buf.samples[buf.samples.length - 1];
+  if (!last || tNow - last.t >= SAMPLE_MS) {
+    buf.samples.push({ t: tNow, chars: buf.chars });
+  } else {
+    // Coalesce into the most recent sample to cap point density.
+    last.t = tNow;
+    last.chars = buf.chars;
+  }
+  buf.lastT = tNow;
+}
+
+// Current instantaneous throughput (chars/sec) over a trailing window.
+export function recentCharsPerSec(buf: LaneBuffer, windowMs = 1000): number {
+  const n = buf.samples.length;
+  if (n < 2) return 0;
+  const end = buf.samples[n - 1];
+  let start = buf.samples[0];
+  for (let i = n - 1; i >= 0; i--) {
+    if (end.t - buf.samples[i].t >= windowMs) {
+      start = buf.samples[i];
+      break;
+    }
+  }
+  const dt = (end.t - start.t) / 1000;
+  if (dt <= 0) return 0;
+  return (end.chars - start.chars) / dt;
+}
+
+// Down-sample a sample list to at most `maxPoints` for drawing, preserving first/last.
+export function decimate(samples: LaneSample[], maxPoints = 180): LaneSample[] {
+  const n = samples.length;
+  if (n <= maxPoints) return samples;
+  const out: LaneSample[] = [];
+  const stride = (n - 1) / (maxPoints - 1);
+  for (let i = 0; i < maxPoints - 1; i++) {
+    out.push(samples[Math.round(i * stride)]);
+  }
+  out.push(samples[n - 1]);
+  return out;
+}


### PR DESCRIPTION
## What & why

The app is called *Drag Racing*, but the race was never visual — lanes were static cards, charts were post-hoc, and there was no winner moment. This overhaul turns it into a real, **truthful** racing experience while keeping the existing premium glass/OLED identity.

## Highlights

### 🏁 Live drag strip (new default view)
Dragsters launch off the line at their **first token (TTFT)**, position = share of output streamed, speed-streak trails scale with throughput, the leader is crowned, and cars lunge across the checkered on finish. Driven by one `requestAnimationFrame` loop reading ref buffers — **zero React re-renders per token**. A **Strip / Telemetry** toggle swaps to the analytical pace chart.

### 📈 Honest visualizations
- **Live pace chart** (`LivePaceChart.tsx`): hand-rolled SVG, each line offset by its real TTFT, value flags, sweeping cursor, freezes on finish.
- **Standings ticker** (`StandingsTicker.tsx`): colorblind/screen-reader-safe live ranking with FLIP reordering — the accessible source of truth.
- **Winner's Circle** (`WinnerPodium.tsx`): unified podium with a mode-aware champion-metric selector, plus **Pole** (best TTFT) and **Fastest Lap** (peak tok/s).
- **18-provider palette** (`providerColors.ts`): every provider gets a unique OLED-safe color (+ hash fallback) — no more cyan collisions across lanes/charts/podium.

### ⚙️ Live race engine
Per-token `RECEIVE_CHUNK` (which re-mapped the whole results array ~100×/sec) is replaced with per-lane ref buffers + a throttled `COMMIT_TEXT` batch. Real client first-token time replaces the synthetic `+100ms`.

### 🚦 Onboarding + demo
- Guided empty state directs first-time visitors to the **Racers sidebar** to add keys & pick models.
- A separate, clearly-labeled **simulated Demo race** (no API key) lets visitors preview the viz. `START RACE` remains the primary flow.

### ✅ Correctness & a11y (from an adversarial review)
- Start disabled mid-race + `AbortController` cancels streams on reset.
- `time_limit` no longer drops the final metrics event; a 0-token lane can't win Pole; degenerate sub-150ms tok/s ignored.
- **Truthfulness:** token counts relabeled as *estimates* (17/18 providers estimate `length/4`) — removed the false "provider-reported" claims.
- `aria-live` race announcements, `aria-pressed`/`role=radio` on toggles, global `prefers-reduced-motion` guard, `React.memo` on lanes.

## Reviewer notes
- TypeScript, ESLint, and `next build` are all clean; verified every UI state live (onboarding → demo countdown → strip/telemetry → standings → podium → charts → reset → mobile drawer) with no console errors.
- The **real** provider-streaming path couldn't be exercised without API keys, but it runs through the exact same state machine/renderers as the verified demo. A quick `npm run dev` with one real key is recommended to close that gap.
- Files: 5 new (`DragStrip`, `LivePaceChart`, `StandingsTicker`, `WinnerPodium`, `raceBuffers`) + 6 modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)