### PR TITLE
Implement list-models for remaining AI providers

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -7,6 +7,28 @@ type ModelResponse = {
 
 // Comprehensive static fallback lists for when API calls fail
 const STATIC_FALLBACKS: Record<string, string[]> = {
+    perplexity: [
+        'sonar',
+        'sonar-pro',
+        'sonar-reasoning',
+        'sonar-reasoning-pro',
+    ],
+    xai: [
+        'grok-2-latest',
+        'grok-3',
+        'grok-3-mini',
+        'grok-3-reasoning',
+    ],
+    deepseek: [
+        'deepseek-chat',
+        'deepseek-reasoner',
+    ],
+    ai21: [
+        'jamba-1.5-mini',
+        'jamba-1.5-large',
+        'jamba-large-1.7-2025-07',
+        'jamba-mini-2-2026-01',
+    ],
     groq: [
         // Llama 3/3.1/3.3 Series
         'llama-3.3-70b-versatile',
@@ -227,7 +249,7 @@ export default async function handler(req: Request): Promise<Response> {
             }
         }
 
-        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere'].includes(providerId)) {
+        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere', 'perplexity', 'xai', 'deepseek', 'ai21'].includes(providerId)) {
             // Standard OpenAI-compatible listing
             const urls: Record<string, string> = {
                 openai: 'https://api.openai.com/v1/models',
@@ -236,6 +258,10 @@ export default async function handler(req: Request): Promise<Response> {
                 together: 'https://api.together.xyz/v1/models',
                 mistral: 'https://api.mistral.ai/v1/models',
                 cohere: 'https://api.cohere.com/v1/models',
+                perplexity: 'https://api.perplexity.ai/models',
+                xai: 'https://api.x.ai/v1/models',
+                deepseek: 'https://api.deepseek.com/models',
+                ai21: 'https://api.ai21.com/studio/v1/models',
             };
 
             const url = urls[providerId];

--- a/utils/fetchModels.ts
+++ b/utils/fetchModels.ts
@@ -370,21 +370,54 @@ export async function performTogetherInference({
 }
 
 // --- Additional provider model fetcher stubs ---
-// TODO: Replace these with real list-models calls once APIs are integrated.
-export async function fetchPerplexityModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchPerplexityModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('perplexity', apiKey);
+  } catch (e) {
+    return [
+      'sonar',
+      'sonar-pro',
+      'sonar-reasoning',
+      'sonar-reasoning-pro'
+    ];
+  }
 }
 
-export async function fetchXaiModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchXaiModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('xai', apiKey);
+  } catch (e) {
+    return [
+      'grok-2-latest',
+      'grok-3',
+      'grok-3-mini',
+      'grok-3-reasoning'
+    ];
+  }
 }
 
-export async function fetchDeepSeekModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchDeepSeekModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('deepseek', apiKey);
+  } catch (e) {
+    return [
+      'deepseek-chat',
+      'deepseek-reasoner'
+    ];
+  }
 }
 
-export async function fetchAI21Models(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchAI21Models(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('ai21', apiKey);
+  } catch (e) {
+    return [
+      'jamba-1.5-mini',
+      'jamba-1.5-large',
+      'jamba-large-1.7-2025-07',
+      'jamba-mini-2-2026-01'
+    ];
+  }
 }
 
 // Cerebras model listing - static list since they have fixed models


### PR DESCRIPTION
- Replaced the placeholder stubs in `utils/fetchModels.ts` with actual API calls through `fetchViaProxy` for Perplexity, xAI, DeepSeek, and AI21.
- Updated the backend API proxy logic in `pages/api/models.ts` to correctly handle routing requests and setting headers for these new providers.
- Supplied sensible hardcoded static model list fallbacks for scenarios where the APIs fail or rate limit.

---
*PR created automatically by Jules for task [5173414303141841330](https://jules.google.com/task/5173414303141841330) started by @JonathanRReed*