### PR TITLE
🧹 Implement API fetchers for Perplexity, xAI, and DeepSeek

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -99,6 +99,22 @@ const STATIC_FALLBACKS: Record<string, string[]> = {
         'o3-mini',
         'gpt-5-preview',
     ],
+    perplexity: [
+        'sonar-reasoning-pro',
+        'sonar-reasoning',
+        'sonar-pro',
+        'sonar',
+    ],
+    xai: [
+        'grok-2-1212',
+        'grok-2-vision-1212',
+        'grok-2',
+        'grok-2-vision',
+    ],
+    deepseek: [
+        'deepseek-chat',
+        'deepseek-reasoner',
+    ]
 };
 
 // Sanitize API key - trim whitespace and remove any accidental quotes
@@ -227,7 +243,7 @@ export default async function handler(req: Request): Promise<Response> {
             }
         }
 
-        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere'].includes(providerId)) {
+        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere', 'perplexity', 'xai', 'deepseek'].includes(providerId)) {
             // Standard OpenAI-compatible listing
             const urls: Record<string, string> = {
                 openai: 'https://api.openai.com/v1/models',
@@ -236,6 +252,9 @@ export default async function handler(req: Request): Promise<Response> {
                 together: 'https://api.together.xyz/v1/models',
                 mistral: 'https://api.mistral.ai/v1/models',
                 cohere: 'https://api.cohere.com/v1/models',
+                perplexity: 'https://api.perplexity.ai/models',
+                xai: 'https://api.x.ai/v1/models',
+                deepseek: 'https://api.deepseek.com/models',
             };
 
             const url = urls[providerId];

--- a/utils/fetchModels.ts
+++ b/utils/fetchModels.ts
@@ -370,17 +370,32 @@ export async function performTogetherInference({
 }
 
 // --- Additional provider model fetcher stubs ---
-// TODO: Replace these with real list-models calls once APIs are integrated.
-export async function fetchPerplexityModels(_apiKey: string): Promise<string[]> {
-  return [];
+// Removed TODO because we are replacing them now
+export async function fetchPerplexityModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('perplexity', apiKey);
+  } catch (e) {
+    console.warn('[Perplexity] fetchPerplexityModels failed:', e);
+    return [];
+  }
 }
 
-export async function fetchXaiModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchXaiModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('xai', apiKey);
+  } catch (e) {
+    console.warn('[xAI] fetchXaiModels failed:', e);
+    return [];
+  }
 }
 
-export async function fetchDeepSeekModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchDeepSeekModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('deepseek', apiKey);
+  } catch (e) {
+    console.warn('[DeepSeek] fetchDeepSeekModels failed:', e);
+    return [];
+  }
 }
 
 export async function fetchAI21Models(_apiKey: string): Promise<string[]> {


### PR DESCRIPTION
🎯 **What:**
The code health issue addressed is the presence of unimplemented API fetcher stubs for Perplexity, xAI, and DeepSeek in `utils/fetchModels.ts`. We have implemented these fetchers by making them use the existing `fetchViaProxy` utility and correctly updated the API proxy endpoint in `pages/api/models.ts`.

💡 **Why:**
This improves maintainability by removing "TODO" dead code and integrating the latest providers cleanly into the pre-existing system for fetching provider models. This ensures uniform API usage without repeating similar configurations. We also added base model fallback lists for these three providers inside `pages/api/models.ts` in case their actual API calls fail.

✅ **Verification:**
- Ran `pnpm install` and `pnpm build` to ensure project builds correctly.
- Ran `pnpm lint` to ensure no linting regressions.
- Visually inspected diff to ensure it matched the expected design logic of mapping arrays and handling API routes cleanly.

✨ **Result:**
The `fetchPerplexityModels`, `fetchXaiModels`, and `fetchDeepSeekModels` functions now properly fetch real API lists using `fetchViaProxy` instead of returning hardcoded empty lists, while using safe fallbacks when a request fails.

---
*PR created automatically by Jules for task [3574891533428664646](https://jules.google.com/task/3574891533428664646) started by @JonathanRReed*