### PR TITLE
🧹 Implement API fetchers for Perplexity, XAI, and DeepSeek

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -7,6 +7,29 @@ type ModelResponse = {
 
 // Comprehensive static fallback lists for when API calls fail
 const STATIC_FALLBACKS: Record<string, string[]> = {
+
+    perplexity: [
+        'sonar-reasoning-pro',
+        'sonar-reasoning',
+        'sonar-pro',
+        'sonar',
+        'llama-3.1-sonar-large-128k-online',
+        'llama-3.1-sonar-small-128k-online',
+        'llama-3.1-sonar-large-128k-chat',
+        'llama-3.1-sonar-small-128k-chat'
+    ],
+    xai: [
+        'grok-2',
+        'grok-2-latest',
+        'grok-2-vision',
+        'grok-2-vision-latest',
+        'grok-beta',
+        'grok-vision-beta'
+    ],
+    deepseek: [
+        'deepseek-chat',
+        'deepseek-reasoner'
+    ],
     groq: [
         // Llama 3/3.1/3.3 Series
         'llama-3.3-70b-versatile',
@@ -227,7 +250,7 @@ export default async function handler(req: Request): Promise<Response> {
             }
         }
 
-        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere'].includes(providerId)) {
+        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere', 'perplexity', 'xai', 'deepseek'].includes(providerId)) {
             // Standard OpenAI-compatible listing
             const urls: Record<string, string> = {
                 openai: 'https://api.openai.com/v1/models',
@@ -236,6 +259,10 @@ export default async function handler(req: Request): Promise<Response> {
                 together: 'https://api.together.xyz/v1/models',
                 mistral: 'https://api.mistral.ai/v1/models',
                 cohere: 'https://api.cohere.com/v1/models',
+
+                perplexity: 'https://api.perplexity.ai/v1/models',
+                xai: 'https://api.x.ai/v1/models',
+                deepseek: 'https://api.deepseek.com/models',
             };
 
             const url = urls[providerId];

--- a/utils/fetchModels.ts
+++ b/utils/fetchModels.ts
@@ -369,18 +369,52 @@ export async function performTogetherInference({
   }
 }
 
-// --- Additional provider model fetcher stubs ---
-// TODO: Replace these with real list-models calls once APIs are integrated.
-export async function fetchPerplexityModels(_apiKey: string): Promise<string[]> {
-  return [];
+// --- Additional provider model fetchers ---
+
+export async function fetchPerplexityModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('perplexity', apiKey);
+  } catch (e) {
+    console.warn('[Perplexity] fetchPerplexityModels failed, using fallback:', e);
+    return [
+      'sonar-reasoning-pro',
+      'sonar-reasoning',
+      'sonar-pro',
+      'sonar',
+      'llama-3.1-sonar-large-128k-online',
+      'llama-3.1-sonar-small-128k-online',
+      'llama-3.1-sonar-large-128k-chat',
+      'llama-3.1-sonar-small-128k-chat'
+    ];
+  }
 }
 
-export async function fetchXaiModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchXaiModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('xai', apiKey);
+  } catch (e) {
+    console.warn('[XAI] fetchXaiModels failed, using fallback:', e);
+    return [
+      'grok-2',
+      'grok-2-latest',
+      'grok-2-vision',
+      'grok-2-vision-latest',
+      'grok-beta',
+      'grok-vision-beta'
+    ];
+  }
 }
 
-export async function fetchDeepSeekModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchDeepSeekModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('deepseek', apiKey);
+  } catch (e) {
+    console.warn('[DeepSeek] fetchDeepSeekModels failed, using fallback:', e);
+    return [
+      'deepseek-chat',
+      'deepseek-reasoner'
+    ];
+  }
 }
 
 export async function fetchAI21Models(_apiKey: string): Promise<string[]> {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The stub functions for fetching models from Perplexity, XAI, and DeepSeek in `utils/fetchModels.ts` were empty arrays and unimplemented. This PR replaces those stubs with actual functional calls to the internal proxy endpoint (`pages/api/models.ts`), adds accurate robust fallback lists if the calls fail, and also properly registers the three providers in the server-side API proxy.

💡 **Why:** How this improves maintainability
Implementing the missing fetch logic standardizes how models are retrieved across all providers and ensures that integrating these platforms actually lists the correct current models dynamically, falling back securely to a known set of models if keys or APIs fail.

✅ **Verification:** How you confirmed the change is safe
- Verified standard fetch structure matches other existing implementations (`await fetchViaProxy('provider', apiKey)` wrapped in try/catch).
- Tested the Next.js API build by running `pnpm run build` and `pnpm lint` and confirmed that everything type-checks cleanly and builds properly without errors.
- Code Review confirmed the changes are correct and safe.

✨ **Result:** The improvement achieved
Perplexity, XAI, and DeepSeek now correctly and dynamically fetch their supported models using the proxy architecture instead of statically returning an empty `[]`.

---
*PR created automatically by Jules for task [8406004912378166987](https://jules.google.com/task/8406004912378166987) started by @JonathanRReed*