### PR TITLE
feat: Implement real list-models calls for Perplexity, xAI, DeepSeek, and AI21

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -227,7 +227,7 @@ export default async function handler(req: Request): Promise<Response> {
             }
         }
 
-        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere'].includes(providerId)) {
+        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere', 'perplexity', 'xai', 'deepseek', 'ai21'].includes(providerId)) {
             // Standard OpenAI-compatible listing
             const urls: Record<string, string> = {
                 openai: 'https://api.openai.com/v1/models',
@@ -236,6 +236,10 @@ export default async function handler(req: Request): Promise<Response> {
                 together: 'https://api.together.xyz/v1/models',
                 mistral: 'https://api.mistral.ai/v1/models',
                 cohere: 'https://api.cohere.com/v1/models',
+                perplexity: 'https://api.perplexity.ai/v1/models',
+                xai: 'https://api.x.ai/v1/models',
+                deepseek: 'https://api.deepseek.com/models',
+                ai21: 'https://api.ai21.com/studio/v1/models',
             };
 
             const url = urls[providerId];

--- a/utils/fetchModels.ts
+++ b/utils/fetchModels.ts
@@ -370,21 +370,20 @@ export async function performTogetherInference({
 }
 
 // --- Additional provider model fetcher stubs ---
-// TODO: Replace these with real list-models calls once APIs are integrated.
-export async function fetchPerplexityModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchPerplexityModels(apiKey: string): Promise<string[]> {
+  return await fetchViaProxy('perplexity', apiKey);
 }
 
-export async function fetchXaiModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchXaiModels(apiKey: string): Promise<string[]> {
+  return await fetchViaProxy('xai', apiKey);
 }
 
-export async function fetchDeepSeekModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchDeepSeekModels(apiKey: string): Promise<string[]> {
+  return await fetchViaProxy('deepseek', apiKey);
 }
 
-export async function fetchAI21Models(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchAI21Models(apiKey: string): Promise<string[]> {
+  return await fetchViaProxy('ai21', apiKey);
 }
 
 // Cerebras model listing - static list since they have fixed models


### PR DESCRIPTION
Replace stub model fetching functions for Perplexity, xAI, DeepSeek, and AI21 with actual API calls to retrieve their models via proxy. Updated `pages/api/models.ts` to include these providers in the OpenAI-compatible listing block and added their respective API endpoints.

---
*PR created automatically by Jules for task [12708235848728184634](https://jules.google.com/task/12708235848728184634) started by @JonathanRReed*