### PR TITLE
🧹 Remove leftover console.log in proxy models API

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -284,7 +284,6 @@ export default async function handler(req: Request): Promise<Response> {
         // Return fallback data instead of error when possible
         const fallback = STATIC_FALLBACKS[providerId];
         if (fallback && fallback.length > 0) {
-            console.log(`[Proxy] Returning fallback for ${providerId}`);
             return jsonResponse({ data: fallback });
         }
 


### PR DESCRIPTION
🎯 What: Removed the leftover console.log statement in `pages/api/models.ts` when returning fallback data.
💡 Why: Logging in API routes can clutter server logs. The removed statement was non-essential.
✅ Verification: Tested locally and ran `pnpm lint` and `pnpm test` successfully.
✨ Result: Cleaner server logs and slightly improved code health.

---
*PR created automatically by Jules for task [769857455463123754](https://jules.google.com/task/769857455463123754) started by @JonathanRReed*