### PR TITLE
🧹 [code health] Implement missing model fetcher stubs for Perplexity, xAI, DeepSeek

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -99,6 +99,27 @@ const STATIC_FALLBACKS: Record<string, string[]> = {
         'o3-mini',
         'gpt-5-preview',
     ],
+    perplexity: [
+        'sonar-reasoning-pro',
+        'sonar-reasoning',
+        'sonar-pro',
+        'sonar',
+        'llama-3.1-sonar-small-128k-online',
+        'llama-3.1-sonar-large-128k-online',
+        'llama-3.1-sonar-huge-128k-online',
+    ],
+    xai: [
+        'grok-2',
+        'grok-2-vision',
+        'grok-2-mini',
+        'grok-2-vision-mini',
+        'grok-beta',
+    ],
+    deepseek: [
+        'deepseek-chat',
+        'deepseek-reasoner',
+        'deepseek-coder',
+    ],
 };
 
 // Sanitize API key - trim whitespace and remove any accidental quotes
@@ -227,7 +248,7 @@ export default async function handler(req: Request): Promise<Response> {
             }
         }
 
-        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere'].includes(providerId)) {
+        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere', 'perplexity', 'xai', 'deepseek'].includes(providerId)) {
             // Standard OpenAI-compatible listing
             const urls: Record<string, string> = {
                 openai: 'https://api.openai.com/v1/models',
@@ -236,6 +257,9 @@ export default async function handler(req: Request): Promise<Response> {
                 together: 'https://api.together.xyz/v1/models',
                 mistral: 'https://api.mistral.ai/v1/models',
                 cohere: 'https://api.cohere.com/v1/models',
+                perplexity: 'https://api.perplexity.ai/models',
+                xai: 'https://api.x.ai/v1/models',
+                deepseek: 'https://api.deepseek.com/models',
             };
 
             const url = urls[providerId];

--- a/utils/fetchModels.ts
+++ b/utils/fetchModels.ts
@@ -370,17 +370,28 @@ export async function performTogetherInference({
 }
 
 // --- Additional provider model fetcher stubs ---
-// TODO: Replace these with real list-models calls once APIs are integrated.
-export async function fetchPerplexityModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchPerplexityModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('perplexity', apiKey);
+  } catch (e) {
+    return [];
+  }
 }
 
-export async function fetchXaiModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchXaiModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('xai', apiKey);
+  } catch (e) {
+    return [];
+  }
 }
 
-export async function fetchDeepSeekModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchDeepSeekModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('deepseek', apiKey);
+  } catch (e) {
+    return [];
+  }
 }
 
 export async function fetchAI21Models(_apiKey: string): Promise<string[]> {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced empty model fetcher stubs in `utils/fetchModels.ts` with real API calls via the existing `fetchViaProxy` utility. Updated the `/api/models` proxy route to properly forward requests to Perplexity, xAI, and DeepSeek, and added static fallbacks for reliability.

💡 **Why:** How this improves maintainability
Improves the maintainability and functionality of the application by integrating the APIs properly using existing codebase patterns, removing technical debt (empty TODO stubs).

✅ **Verification:** How you confirmed the change is safe
Verified visually via `git diff` that changes perfectly match existing proxy-based fetching logic. Ran `pnpm lint` and `pnpm test` to ensure code health is preserved and no regressions were introduced.

✨ **Result:** The improvement achieved
`fetchPerplexityModels`, `fetchXaiModels`, and `fetchDeepSeekModels` are now fully functional and properly resilient using `STATIC_FALLBACKS`.

---
*PR created automatically by Jules for task [17872343008342608444](https://jules.google.com/task/17872343008342608444) started by @JonathanRReed*