### PR TITLE
🧹 Remove leftover console.log in proxy models API

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -284,7 +284,6 @@ export default async function handler(req: Request): Promise<Response> {
         // Return fallback data instead of error when possible
         const fallback = STATIC_FALLBACKS[providerId];
         if (fallback && fallback.length > 0) {
-            console.log(`[Proxy] Returning fallback for ${providerId}`);
             return jsonResponse({ data: fallback });
         }
 


### PR DESCRIPTION
🎯 **What:** Removed the `console.log` statement that prints "[Proxy] Returning fallback for..." in `pages/api/models.ts`.
💡 **Why:** This prevents server log clutter, as returning a fallback is expected behavior when primary requests fail, and does not require constant logging.
✅ **Verification:** Ran `pnpm lint` which passed cleanly. Checked that no logic or error-handling was altered by removing the log.
✨ **Result:** Cleaner server logs and slightly improved code hygiene without affecting proxy functionality.

---
*PR created automatically by Jules for task [9634009857876385846](https://jules.google.com/task/9634009857876385846) started by @JonathanRReed*