### PR TITLE
🧹 [code health improvement] Implement fetchers for Perplexity, XAI, and DeepSeek models

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -86,6 +86,21 @@ const STATIC_FALLBACKS: Record<string, string[]> = {
         // Code
         'codegeex-4',
     ],
+    perplexity: [
+        'sonar-reasoning-pro',
+        'sonar-reasoning',
+        'sonar-pro',
+        'sonar'
+    ],
+    xai: [
+        'grok-2-latest',
+        'grok-2-vision-latest',
+        'grok-beta'
+    ],
+    deepseek: [
+        'deepseek-chat',
+        'deepseek-reasoner'
+    ],
     openai: [
         'gpt-4o',
         'gpt-4o-mini',
@@ -227,9 +242,12 @@ export default async function handler(req: Request): Promise<Response> {
             }
         }
 
-        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere'].includes(providerId)) {
+        else if (['openai', 'fireworks', 'openrouter', 'together', 'mistral', 'cohere', 'perplexity', 'xai', 'deepseek'].includes(providerId)) {
             // Standard OpenAI-compatible listing
             const urls: Record<string, string> = {
+                perplexity: 'https://api.perplexity.ai/v1/models',
+                xai: 'https://api.x.ai/v1/models',
+                deepseek: 'https://api.deepseek.com/models',
                 openai: 'https://api.openai.com/v1/models',
                 fireworks: 'https://api.fireworks.ai/inference/v1/models',
                 openrouter: 'https://openrouter.ai/api/v1/models',

--- a/utils/fetchModels.ts
+++ b/utils/fetchModels.ts
@@ -370,17 +370,41 @@ export async function performTogetherInference({
 }
 
 // --- Additional provider model fetcher stubs ---
-// TODO: Replace these with real list-models calls once APIs are integrated.
-export async function fetchPerplexityModels(_apiKey: string): Promise<string[]> {
-  return [];
+
+export async function fetchPerplexityModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('perplexity', apiKey);
+  } catch (e) {
+    return [
+      'sonar-reasoning-pro',
+      'sonar-reasoning',
+      'sonar-pro',
+      'sonar'
+    ];
+  }
 }
 
-export async function fetchXaiModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchXaiModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('xai', apiKey);
+  } catch (e) {
+    return [
+      'grok-2-latest',
+      'grok-2-vision-latest',
+      'grok-beta'
+    ];
+  }
 }
 
-export async function fetchDeepSeekModels(_apiKey: string): Promise<string[]> {
-  return [];
+export async function fetchDeepSeekModels(apiKey: string): Promise<string[]> {
+  try {
+    return await fetchViaProxy('deepseek', apiKey);
+  } catch (e) {
+    return [
+      'deepseek-chat',
+      'deepseek-reasoner'
+    ];
+  }
 }
 
 export async function fetchAI21Models(_apiKey: string): Promise<string[]> {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The stubs for fetching models from Perplexity, XAI, and DeepSeek within `utils/fetchModels.ts` were unimplemented and returned empty arrays. 

💡 **Why:** How this improves maintainability
The codebase architecture centralizes model fetching via a backend proxy at `pages/api/models.ts` with error handling and static fallbacks in case APIs fail. The unimplemented stubs ignored this architectural pattern. By implementing these providers properly using the `fetchViaProxy` utility and correctly updating the proxy endpoint mappings and its `STATIC_FALLBACKS` fallback records, the codebase ensures a predictable structure, removing the "stubbed" functionality entirely and increasing future robustness and adherence to the API design.

✅ **Verification:** How you confirmed the change is safe
- Tested the individual providers' API URLs to determine valid response patterns and current fallback lists.
- Implemented the same pattern successfully used for existing providers (like OpenAI, Anthropic, Moonshot, etc.).
- Evaluated `fetchViaProxy` and verified that the `catch` blocks properly return the hardcoded default arrays if the endpoint proxy errors out, keeping the functionality fully safe.
- Ran `pnpm build` and `pnpm lint` without issue.

✨ **Result:** The improvement achieved
The fetch functions are now completely integrated into the proxy system, and the backend provides valid base proxy routes (`pages/api/models.ts`) and resilient fallback lists for these 3 specific AI providers, removing the technical debt.

---
*PR created automatically by Jules for task [10011680812815377688](https://jules.google.com/task/10011680812815377688) started by @JonathanRReed*