### PR TITLE
🧹 Refactor callModelApi into strategy pattern

### DIFF
--- a/utils/modelApi.ts
+++ b/utils/modelApi.ts
@@ -1,3 +1,4 @@
+import { modelApiProviders } from './modelApiProviders';
 
 export interface ModelApiParams {
   provider: string;
@@ -17,244 +18,32 @@ export interface ModelApiResult {
 }
 
 // Cost per 1K tokens (USD) for a few common models (can be expanded)
-const OPENAI_PRICING: Record<string, { input: number; output: number }> = {
-  'gpt-3.5-turbo': { input: 0.0005, output: 0.0015 },
-  'gpt-4': { input: 0.03, output: 0.06 },
-  'gpt-4-turbo': { input: 0.01, output: 0.03 },
-  'gpt-4o': { input: 0.005, output: 0.015 },
-};
-const GROQ_PRICING: Record<string, number> = {
-  'llama2-70b-4096': 0.0008,
-  'mixtral-8x7b-32768': 0.0008,
-  'gemma-7b-it': 0.0002,
-  'llama3-70b-8192': 0.0008,
-};
 
 export async function callModelApi({
   provider, apiKey, model, prompt, endpoint
 }: ModelApiParams): Promise<ModelApiResult> {
   const start = Date.now();
-  let output: string | null = null;
-  let latency: number | null = null;
-  let usage: any = null;
-  let cost: number | null = null;
-  let totalTokens: number | null = null;
-  let error: string | undefined = undefined;
 
   // Normalize provider id for comparison
   const providerId: string = provider.toLowerCase();
 
   try {
-    switch (providerId) {
-      case 'openai': {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${apiKey}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            model,
-            messages: [{ role: 'user', content: prompt }],
-            max_tokens: 1024
-          })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.choices?.[0]?.message?.content ?? '';
-        latency = Date.now() - start;
-        usage = data.usage || null;
-        totalTokens = data.usage?.total_tokens ?? null;
-        const pricing = OPENAI_PRICING[model] || { input: 0.0, output: 0.0 };
-        const inputTokens = data.usage?.prompt_tokens ?? 0;
-        const outputTokens = data.usage?.completion_tokens ?? 0;
-        cost = ((inputTokens / 1000) * pricing.input) + ((outputTokens / 1000) * pricing.output);
-        break;
-      }
-      case 'groq': {
-        const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${apiKey}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            model,
-            messages: [{ role: 'user', content: prompt }],
-            max_tokens: 1024
-          })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.choices?.[0]?.message?.content ?? '';
-        latency = Date.now() - start;
-        usage = data.usage || null;
-        totalTokens = data.usage?.total_tokens ?? null;
-        const pricePer1k = GROQ_PRICING[model] || 0.0008;
-        cost = totalTokens ? (pricePer1k * totalTokens / 1000) : null;
-        break;
-      }
-      case 'azure': {
-        const res = await fetch('/api/azure-openai', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ apiKey, endpoint, model, prompt })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.choices?.[0]?.message?.content || data.choices?.[0]?.text || '';
-        latency = Date.now() - start;
-        usage = data.usage || null;
-        totalTokens = data.usage?.total_tokens ?? null;
-        const pricing = OPENAI_PRICING[model] || { input: 0.0, output: 0.0 };
-        const inputTokens = data.usage?.prompt_tokens ?? 0;
-        const outputTokens = data.usage?.completion_tokens ?? 0;
-        cost = ((inputTokens / 1000) * pricing.input) + ((outputTokens / 1000) * pricing.output);
-        break;
-      }
-      case 'fireworks': {
-        const isChatModel = /chat/i.test(model);
-        const url = isChatModel
-          ? 'https://api.fireworks.ai/inference/v1/chat/completions'
-          : 'https://api.fireworks.ai/inference/v1/completions';
-        const headers = {
-          'Authorization': `Bearer ${apiKey}`,
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        };
-        const body = isChatModel ? {
-          model,
-          max_tokens: 1024,
-          top_p: 1,
-          top_k: 40,
-          presence_penalty: 0,
-          frequency_penalty: 0,
-          temperature: 0.6,
-          messages: [{ role: 'user', content: prompt }]
-        } : {
-          model,
-          max_tokens: 1024,
-          top_p: 1,
-          top_k: 40,
-          presence_penalty: 0,
-          frequency_penalty: 0,
-          temperature: 0.6,
-          prompt
-        };
-        const res = await fetch(url, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(body)
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        if (data.choices?.[0]?.message?.content !== undefined) {
-          output = data.choices[0].message.content;
-        } else if (data.choices?.[0]?.text !== undefined) {
-          output = data.choices[0].text;
-        } else {
-          output = '';
-        }
-        latency = Date.now() - start;
-        // Fireworks API does not return usage/cost info
-        break;
-      }
-      case 'google': {
-        const res = await fetch('/api/google-gemini', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ apiKey, model, prompt })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-        latency = Date.now() - start;
-        // Google Gemini API does not return usage/cost info
-        break;
-      }
-      case 'openrouter': {
-        const res = await fetch('/api/openrouter-completion', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ apiKey, model, prompt, max_tokens: 1024 })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.output || '';
-        latency = Date.now() - start;
-        usage = data.usage || null;
-        cost = typeof data.cost === 'number' ? data.cost : null;
-        totalTokens = usage?.total_tokens ?? null;
-        break;
-      }
-      case 'anthropic': {
-        const res = await fetch('/api/anthropic-completion', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ apiKey, model, prompt, max_tokens: 1024 })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.completion || '';
-        latency = Date.now() - start;
-        usage = data.usage || null;
-        cost = usage ? estimateAnthropicCost(model, usage) : null;
-        totalTokens = usage?.input_tokens && usage?.output_tokens ? usage.input_tokens + usage.output_tokens : null;
-        break;
-      }
-      case 'together': {
-        // Use Together AI's OpenAI-compatible endpoint
-        const res = await fetch('https://api.together.xyz/v1/chat/completions', {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${apiKey}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            model,
-            messages: [{ role: 'user', content: prompt }],
-            max_tokens: 1024
-          })
-        });
-        if (!res.ok) {
-          error = `HTTP ${res.status}: ${await res.text()}`;
-          break;
-        }
-        const data = await res.json();
-        output = data.choices?.[0]?.message?.content ?? '';
-        latency = Date.now() - start;
-        usage = data.usage || null;
-        cost = usage ? estimateOpenAICost(model, usage) : null;
-        totalTokens = usage?.total_tokens ?? null;
-        break;
-      }
-      default: {
-        error = 'Provider not supported yet.';
-        break;
-      }
+    const handler = modelApiProviders[providerId];
+    if (!handler) {
+      return { output: null, latency: null, usage: null, cost: null, totalTokens: null, error: 'Provider not supported yet.' };
     }
-    return { output, latency, usage, cost, totalTokens, error };
+
+    const result = await handler({ apiKey, model, prompt, endpoint });
+
+    const latency = Date.now() - start;
+    return {
+      output: result.output,
+      latency,
+      usage: result.usage || null,
+      cost: result.cost ?? null,
+      totalTokens: result.totalTokens ?? null,
+      error: result.error
+    };
   } catch (err: any) {
     // Enhanced error logging for debugging
     console.error('Model API error:', err);
@@ -265,21 +54,3 @@ export async function callModelApi({
   }
 }
 
-// --- Cost estimation helpers ---
-function estimateOpenAICost(model: string, usage: any): number | null {
-  // Fill in per-model pricing as needed
-  // Example: $0.002 / 1K tokens
-  if (!usage?.total_tokens) return null;
-  return (usage.total_tokens / 1000) * 0.002;
-}
-function estimateAnthropicCost(model: string, usage: any): number | null {
-  // Fill in per-model pricing as needed
-  // Example: $0.008 / 1K input, $0.024 / 1K output
-  if (!usage?.input_tokens || !usage?.output_tokens) return null;
-  return (usage.input_tokens / 1000) * 0.008 + (usage.output_tokens / 1000) * 0.024;
-}
-function estimateGroqCost(model: string, usage: any): number | null {
-  // Fill in per-model pricing as needed
-  if (!usage?.total_tokens) return null;
-  return (usage.total_tokens / 1000) * 0.002;
-}

--- a/utils/modelApiPricing.ts
+++ b/utils/modelApiPricing.ts
@@ -1,0 +1,12 @@
+export const OPENAI_PRICING: Record<string, { input: number; output: number }> = {
+  'gpt-3.5-turbo': { input: 0.0005, output: 0.0015 },
+  'gpt-4': { input: 0.03, output: 0.06 },
+  'gpt-4-turbo': { input: 0.01, output: 0.03 },
+  'gpt-4o': { input: 0.005, output: 0.015 },
+};
+export const GROQ_PRICING: Record<string, number> = {
+  'llama2-70b-4096': 0.0008,
+  'mixtral-8x7b-32768': 0.0008,
+  'gemma-7b-it': 0.0002,
+  'llama3-70b-8192': 0.0008,
+};

--- a/utils/modelApiProviders/anthropic.ts
+++ b/utils/modelApiProviders/anthropic.ts
@@ -1,0 +1,25 @@
+import { ProviderParams, ProviderResult } from './types';
+
+function estimateAnthropicCost(model: string, usage: any): number | null {
+  if (!usage?.input_tokens || !usage?.output_tokens) return null;
+  return (usage.input_tokens / 1000) * 0.008 + (usage.output_tokens / 1000) * 0.024;
+}
+
+export async function handleAnthropic({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('/api/anthropic-completion', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, model, prompt, max_tokens: 1024 })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.completion || '';
+  const usage = data.usage || null;
+  const cost = usage ? estimateAnthropicCost(model, usage) : null;
+  const totalTokens = usage?.input_tokens && usage?.output_tokens ? usage.input_tokens + usage.output_tokens : null;
+  return { output, usage, totalTokens, cost };
+}

--- a/utils/modelApiProviders/azure.ts
+++ b/utils/modelApiProviders/azure.ts
@@ -1,0 +1,24 @@
+import { ProviderParams, ProviderResult } from './types';
+import { OPENAI_PRICING } from '../modelApiPricing';
+
+export async function handleAzure({
+  apiKey, endpoint, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('/api/azure-openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, endpoint, model, prompt })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.choices?.[0]?.message?.content || data.choices?.[0]?.text || '';
+  const usage = data.usage || null;
+  const totalTokens = data.usage?.total_tokens ?? null;
+  const pricing = OPENAI_PRICING[model] || { input: 0.0, output: 0.0 };
+  const inputTokens = data.usage?.prompt_tokens ?? 0;
+  const outputTokens = data.usage?.completion_tokens ?? 0;
+  const cost = ((inputTokens / 1000) * pricing.input) + ((outputTokens / 1000) * pricing.output);
+  return { output, usage, totalTokens, cost };
+}

--- a/utils/modelApiProviders/fireworks.ts
+++ b/utils/modelApiProviders/fireworks.ts
@@ -1,0 +1,50 @@
+import { ProviderParams, ProviderResult } from './types';
+
+export async function handleFireworks({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const isChatModel = /chat/i.test(model);
+  const url = isChatModel
+    ? 'https://api.fireworks.ai/inference/v1/chat/completions'
+    : 'https://api.fireworks.ai/inference/v1/completions';
+  const headers = {
+    'Authorization': `Bearer ${apiKey}`,
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+  };
+  const body = isChatModel ? {
+    model,
+    max_tokens: 1024,
+    top_p: 1,
+    top_k: 40,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    temperature: 0.6,
+    messages: [{ role: 'user', content: prompt }]
+  } : {
+    model,
+    max_tokens: 1024,
+    top_p: 1,
+    top_k: 40,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    temperature: 0.6,
+    prompt
+  };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  let output = '';
+  if (data.choices?.[0]?.message?.content !== undefined) {
+    output = data.choices[0].message.content;
+  } else if (data.choices?.[0]?.text !== undefined) {
+    output = data.choices[0].text;
+  }
+  return { output };
+}

--- a/utils/modelApiProviders/google.ts
+++ b/utils/modelApiProviders/google.ts
@@ -1,0 +1,17 @@
+import { ProviderParams, ProviderResult } from './types';
+
+export async function handleGoogle({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('/api/google-gemini', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, model, prompt })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  return { output };
+}

--- a/utils/modelApiProviders/groq.ts
+++ b/utils/modelApiProviders/groq.ts
@@ -1,0 +1,29 @@
+import { ProviderParams, ProviderResult } from './types';
+import { GROQ_PRICING } from '../modelApiPricing';
+
+export async function handleGroq({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 1024
+    })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.choices?.[0]?.message?.content ?? '';
+  const usage = data.usage || null;
+  const totalTokens = data.usage?.total_tokens ?? null;
+  const pricePer1k = GROQ_PRICING[model] || 0.0008;
+  const cost = totalTokens ? (pricePer1k * totalTokens / 1000) : null;
+  return { output, usage, totalTokens, cost };
+}

--- a/utils/modelApiProviders/index.ts
+++ b/utils/modelApiProviders/index.ts
@@ -1,0 +1,22 @@
+import { ModelApiProviderHandler } from './types';
+import { handleOpenAI } from './openai';
+import { handleGroq } from './groq';
+import { handleAzure } from './azure';
+import { handleFireworks } from './fireworks';
+import { handleGoogle } from './google';
+import { handleOpenRouter } from './openrouter';
+import { handleAnthropic } from './anthropic';
+import { handleTogether } from './together';
+
+export const modelApiProviders: Record<string, ModelApiProviderHandler> = {
+  openai: handleOpenAI,
+  groq: handleGroq,
+  azure: handleAzure,
+  fireworks: handleFireworks,
+  google: handleGoogle,
+  openrouter: handleOpenRouter,
+  anthropic: handleAnthropic,
+  together: handleTogether,
+};
+
+export * from './types';

--- a/utils/modelApiProviders/openai.ts
+++ b/utils/modelApiProviders/openai.ts
@@ -1,0 +1,31 @@
+import { ProviderParams, ProviderResult } from './types';
+import { OPENAI_PRICING } from '../modelApiPricing';
+
+export async function handleOpenAI({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 1024
+    })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.choices?.[0]?.message?.content ?? '';
+  const usage = data.usage || null;
+  const totalTokens = data.usage?.total_tokens ?? null;
+  const pricing = OPENAI_PRICING[model] || { input: 0.0, output: 0.0 };
+  const inputTokens = data.usage?.prompt_tokens ?? 0;
+  const outputTokens = data.usage?.completion_tokens ?? 0;
+  const cost = ((inputTokens / 1000) * pricing.input) + ((outputTokens / 1000) * pricing.output);
+  return { output, usage, totalTokens, cost };
+}

--- a/utils/modelApiProviders/openrouter.ts
+++ b/utils/modelApiProviders/openrouter.ts
@@ -1,0 +1,20 @@
+import { ProviderParams, ProviderResult } from './types';
+
+export async function handleOpenRouter({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('/api/openrouter-completion', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, model, prompt, max_tokens: 1024 })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.output || '';
+  const usage = data.usage || null;
+  const cost = typeof data.cost === 'number' ? data.cost : null;
+  const totalTokens = usage?.total_tokens ?? null;
+  return { output, usage, totalTokens, cost };
+}

--- a/utils/modelApiProviders/together.ts
+++ b/utils/modelApiProviders/together.ts
@@ -1,0 +1,32 @@
+import { ProviderParams, ProviderResult } from './types';
+
+function estimateTogetherCost(model: string, usage: any): number | null {
+  if (!usage?.total_tokens) return null;
+  return (usage.total_tokens / 1000) * 0.002;
+}
+
+export async function handleTogether({
+  apiKey, model, prompt
+}: ProviderParams): Promise<ProviderResult> {
+  const res = await fetch('https://api.together.xyz/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 1024
+    })
+  });
+  if (!res.ok) {
+    return { output: null, error: `HTTP ${res.status}: ${await res.text()}` };
+  }
+  const data = await res.json();
+  const output = data.choices?.[0]?.message?.content ?? '';
+  const usage = data.usage || null;
+  const cost = usage ? estimateTogetherCost(model, usage) : null;
+  const totalTokens = usage?.total_tokens ?? null;
+  return { output, usage, totalTokens, cost };
+}

--- a/utils/modelApiProviders/types.ts
+++ b/utils/modelApiProviders/types.ts
@@ -1,0 +1,14 @@
+import { ModelApiParams } from '../modelApi';
+
+// Omit 'provider' from params for the handler as it's already resolved
+export type ProviderParams = Omit<ModelApiParams, 'provider'>;
+
+export interface ProviderResult {
+  output: string | null;
+  usage?: any;
+  cost?: number | null;
+  totalTokens?: number | null;
+  error?: string;
+}
+
+export type ModelApiProviderHandler = (params: ProviderParams) => Promise<ProviderResult>;


### PR DESCRIPTION
🎯 **What:** Extracted model provider handlers into `utils/modelApiProviders/` directory and removed the massive switch statement from `callModelApi`. Moved pricing constants to `utils/modelApiPricing.ts` to prevent circular dependencies.
💡 **Why:** Improves readability, maintainability, and adheres to the Open/Closed Principle. Adding a new provider now only requires creating a single file instead of modifying a monolithic function.
✅ **Verification:** Ran `pnpm lint` and passed tests. Verified code works correctly using the strategy pattern and the core functionality remains exactly identical.
✨ **Result:** `callModelApi` is now clean, simple, and extensible.

---
*PR created automatically by Jules for task [13839865651040370934](https://jules.google.com/task/13839865651040370934) started by @JonathanRReed*