### PR TITLE
🔒 Fix partial API key exposure in error logs

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -141,10 +141,6 @@ export default async function handler(req: Request): Promise<Response> {
         return jsonResponse({ data: [], error: 'API key required' }, 400);
     }
 
-    // Log safely for debugging
-    const keySample = apiKey.length > 6
-        ? `${apiKey.substring(0, 4)}...${apiKey.substring(apiKey.length - 4)}`
-        : '[SHORT]';
 
     try {
         let ids: string[] = [];
@@ -278,7 +274,7 @@ export default async function handler(req: Request): Promise<Response> {
         return jsonResponse({ data: ids });
 
     } catch (error: any) {
-        console.error(`[Proxy Error] Provider: ${providerId}, Key: ${keySample}`);
+        console.error(`[Proxy Error] Provider: ${providerId}`);
         console.error(`[Proxy Error] Message: ${error.message}`);
 
         // Return fallback data instead of error when possible


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Partial API keys were being logged in error messages within `pages/api/models.ts` when a fetch request failed.

⚠️ **Risk:** The potential impact if left unfixed
Exposure of API keys in logs could lead to unauthorized access to AI provider endpoints, potentially allowing malicious actors to consume credits or perform unauthorized actions, especially if logs are exposed to unauthorized individuals.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix removes the computation of the `keySample` and modifies the logging statement to only log the `providerId`, thereby preventing any part of the API key from appearing in error outputs or console messages.

---
*PR created automatically by Jules for task [1341705861654288160](https://jules.google.com/task/1341705861654288160) started by @JonathanRReed*